### PR TITLE
Fix artifact bucket name to match existing infrastructure

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -847,7 +847,7 @@ availableSecrets:
     env: GOOGLE_CREDENTIALS
 artifacts:
   objects:
-    location: gs://$PROJECT_ID-terraform-state/build-artifacts
+    location: gs://$PROJECT_ID-terraform/build-artifacts
     paths:
     - $BUILD_ID-status.env
     - $BUILD_ID-plan-summary.txt


### PR DESCRIPTION
The artifacts section was referencing gs://cluster-dreams-terraform-state but the actual bucket is gs://cluster-dreams-terraform, causing build failures during artifact upload. Updated to use correct bucket name.

🤖 Generated with [Claude Code](https://claude.ai/code)