### PR TITLE
Fix Terraform state locking by serializing workspace operations

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -355,7 +355,7 @@ steps:
 - id: setup-dev
   name: hashicorp/terraform:1.11
   waitFor:
-  - security-report
+  - apply-gitops
   entrypoint: /bin/sh
   secretEnv:
   - GOOGLE_CREDENTIALS
@@ -583,6 +583,8 @@ steps:
   timeout: 1800s
 - id: setup-staging
   name: hashicorp/terraform:1.11
+  waitFor:
+  - apply-dev
   entrypoint: /bin/sh
   secretEnv:
   - GOOGLE_CREDENTIALS


### PR DESCRIPTION
Previously, setup-dev and setup-staging ran in parallel after security-report, causing potential Terraform state lock conflicts when multiple workspaces access the same backend simultaneously.

Fixed by creating a serial dependency chain:
- setup-dev now waits for apply-gitops to complete
- setup-staging now waits for apply-dev to complete

This ensures only one Terraform operation runs at a time, preventing state locking issues while maintaining proper workspace isolation.

🤖 Generated with [Claude Code](https://claude.ai/code)