### PR TITLE
Fix google provider version to ~> 7.0 to satisfy GKE module constraints

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -10,11 +10,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.14"
+      version = "~> 7.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.14"
+      version = "~> 7.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
The terraform-google-modules/kubernetes-engine module requires >= 6.19.0 and < 8.0.0 for the google provider, which conflicted with ~> 5.14.

https://claude.ai/code/session_011CUyCZTyJkidQosuhSRALT