### PR TITLE
Fix helm output fallback to match metadata object schema

### DIFF
--- a/modules/helm/output.tf
+++ b/modules/helm/output.tf
@@ -1,4 +1,15 @@
 output "deployment" {
-  value       = var.app["deploy"] ? helm_release.this[0].metadata : {}
+  value = var.app["deploy"] ? helm_release.this[0].metadata : {
+    app_version    = ""
+    chart          = ""
+    first_deployed = 0
+    last_deployed  = 0
+    name           = ""
+    namespace      = ""
+    notes          = ""
+    revision       = 0
+    values         = ""
+    version        = ""
+  }
   description = "The state of the helm deployment"
 }


### PR DESCRIPTION
Helm provider 3.x metadata is an object with typed keys, not a list or map. Provide a matching zero-value object as fallback.

https://claude.ai/code/session_011CUyCZTyJkidQosuhSRALT