### PR TITLE
Fix terraform plan exit code 2 handling with set -e and pipefail

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -216,10 +216,10 @@ steps:
     \ -euo pipefail\n\nworkspace_name=\"gitops\"\nplan_file=\"/workspace/$BUILD_ID/tfplan_gitops\"\
     \nplan_output=\"/tmp/plan_output_${workspace_name}.txt\"\n\necho \"Creating Terraform\
     \ plan for workspace: $workspace_name\"\n\n# Create plan directory\nmkdir -p \"\
-    $(dirname \"$plan_file\")\"\n\n# Generate plan with detailed output\nterraform\
+    $(dirname \"$plan_file\")\"\n\n# Generate plan with detailed output\nset +eo pipefail\nterraform\
     \ plan \\\n    -detailed-exitcode \\\n    -parallelism=30 \\\n    -var=\"compute_engine_service_account=terraform@$PROJECT_ID.iam.gserviceaccount.com\"\
     \ \\\n    -var=\"project_id=$PROJECT_ID\" \\\n    -out=\"$plan_file\" \\\n   \
-    \ | tee \"$plan_output\"\n\n# Check plan exit code\nplan_exit_code=$?\n\ncase\
+    \ | tee \"$plan_output\"\nplan_exit_code=${PIPESTATUS[0]}\nset -e\n\ncase\
     \ $plan_exit_code in\n    0)\n        echo \"No changes detected in plan\"\n \
     \       echo \"PLAN_STATUS=NO_CHANGES\" >> $BUILD_ID-status.env\n        ;;\n\
     \    1)\n        echo \"Plan failed\"\n        exit 1\n        ;;\n    2)\n  \
@@ -445,10 +445,10 @@ steps:
     \ -euo pipefail\n\nworkspace_name=\"dev\"\nplan_file=\"/workspace/$BUILD_ID/tfplan_dev\"\
     \nplan_output=\"/tmp/plan_output_${workspace_name}.txt\"\n\necho \"Creating Terraform\
     \ plan for workspace: $workspace_name\"\n\n# Create plan directory\nmkdir -p \"\
-    $(dirname \"$plan_file\")\"\n\n# Generate plan with detailed output\nterraform\
+    $(dirname \"$plan_file\")\"\n\n# Generate plan with detailed output\nset +eo pipefail\nterraform\
     \ plan \\\n    -detailed-exitcode \\\n    -parallelism=30 \\\n    -var=\"compute_engine_service_account=terraform@$PROJECT_ID.iam.gserviceaccount.com\"\
     \ \\\n    -var=\"project_id=$PROJECT_ID\" \\\n    -out=\"$plan_file\" \\\n   \
-    \ | tee \"$plan_output\"\n\n# Check plan exit code\nplan_exit_code=$?\n\ncase\
+    \ | tee \"$plan_output\"\nplan_exit_code=${PIPESTATUS[0]}\nset -e\n\ncase\
     \ $plan_exit_code in\n    0)\n        echo \"No changes detected in plan\"\n \
     \       echo \"PLAN_STATUS=NO_CHANGES\" >> $BUILD_ID-status.env\n        ;;\n\
     \    1)\n        echo \"Plan failed\"\n        exit 1\n        ;;\n    2)\n  \
@@ -674,10 +674,10 @@ steps:
     \ -euo pipefail\n\nworkspace_name=\"staging\"\nplan_file=\"/workspace/$BUILD_ID/tfplan_staging\"\
     \nplan_output=\"/tmp/plan_output_${workspace_name}.txt\"\n\necho \"Creating Terraform\
     \ plan for workspace: $workspace_name\"\n\n# Create plan directory\nmkdir -p \"\
-    $(dirname \"$plan_file\")\"\n\n# Generate plan with detailed output\nterraform\
+    $(dirname \"$plan_file\")\"\n\n# Generate plan with detailed output\nset +eo pipefail\nterraform\
     \ plan \\\n    -detailed-exitcode \\\n    -parallelism=30 \\\n    -var=\"compute_engine_service_account=terraform@$PROJECT_ID.iam.gserviceaccount.com\"\
     \ \\\n    -var=\"project_id=$PROJECT_ID\" \\\n    -out=\"$plan_file\" \\\n   \
-    \ | tee \"$plan_output\"\n\n# Check plan exit code\nplan_exit_code=$?\n\ncase\
+    \ | tee \"$plan_output\"\nplan_exit_code=${PIPESTATUS[0]}\nset -e\n\ncase\
     \ $plan_exit_code in\n    0)\n        echo \"No changes detected in plan\"\n \
     \       echo \"PLAN_STATUS=NO_CHANGES\" >> $BUILD_ID-status.env\n        ;;\n\
     \    1)\n        echo \"Plan failed\"\n        exit 1\n        ;;\n    2)\n  \


### PR DESCRIPTION
set -euo pipefail causes the script to exit immediately when terraform plan returns exit code 2 (changes detected) through the tee pipe. Fix by disabling errexit/pipefail before the plan command and using PIPESTATUS[0] to capture the actual terraform exit code, then re-enabling errexit after.

https://claude.ai/code/session_011CUyCZTyJkidQosuhSRALT