### PR TITLE
Fix shared network conflict between workspaces

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -4,7 +4,7 @@ module "gke" {
   name                       = "${terraform.workspace}-cluster"
   region                     = var.region
   zones                      = var.zones
-  network                    = module.shared-network.network_name
+  network                    = local.shared_network_name
   subnetwork                 = "gke-subnet-${terraform.workspace}"
   enable_private_nodes       = true
   enable_private_endpoint    = false
@@ -84,8 +84,6 @@ module "gke" {
       "default-node-pool",
     ]
   }
-
-  depends_on = [module.shared-network]
 }
 
 # Grant the Terraform service account container.admin scoped to this cluster

--- a/locals.tf
+++ b/locals.tf
@@ -6,6 +6,8 @@ locals {
     staging = "1"
     gitops  = "2"
   }
+  # Shared network name - use module in dev, data source in others
+  shared_network_name = terraform.workspace == "dev" ? module.shared-network[0].network_name : data.google_compute_network.shared_network[0].name
   apps = {
     # --- Monitoring ---
     prometheus = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,17 +44,17 @@ output "cluster_name" {
 
 output "network_name" {
   description = "The name of the VPC being created"
-  value       = module.shared-network.network_name
+  value       = local.shared_network_name
 }
 
 output "subnet_name" {
   description = "The name of the subnet being created"
-  value       = module.shared-network.subnets_names
+  value       = terraform.workspace == "dev" ? module.shared-network[0].subnets_names : ["gke-subnet-${terraform.workspace}"]
 }
 
 output "subnet_secondary_ranges" {
   description = "The secondary ranges associated with the subnet"
-  value       = module.shared-network.subnets_secondary_ranges
+  value       = terraform.workspace == "dev" ? module.shared-network[0].subnets_secondary_ranges : []
 }
 
 

--- a/shared-network.tf
+++ b/shared-network.tf
@@ -1,8 +1,11 @@
 # Shared Network Infrastructure
 # This creates a single VPC network with one NAT Gateway that all clusters can use
+# Only created in 'dev' workspace to avoid conflicts; other workspaces reference it
 
-# Shared VPC Network (create once, use for all clusters)
+# Shared VPC Network (create once in dev workspace)
 module "shared-network" {
+  count = terraform.workspace == "dev" ? 1 : 0
+
   source  = "terraform-google-modules/network/google"
   version = ">= 4.0.1"
 
@@ -67,19 +70,28 @@ module "shared-network" {
   }
 }
 
-# Single Cloud Router (shared across all clusters)
+# Data source to reference existing network in non-dev workspaces
+data "google_compute_network" "shared_network" {
+  count   = terraform.workspace != "dev" ? 1 : 0
+  project = var.project_id
+  name    = "shared-gke-network"
+}
+
+# Single Cloud Router (shared across all clusters, only created in dev)
 resource "google_compute_router" "shared_router" {
+  count   = terraform.workspace == "dev" ? 1 : 0
   project = var.project_id
   name    = "shared-gke-router"
-  network = module.shared-network.network_name
+  network = module.shared-network[0].network_name
   region  = var.region
 }
 
-# Single Cloud NAT (shared across all clusters)
+# Single Cloud NAT (shared across all clusters, only created in dev)
 resource "google_compute_router_nat" "shared_nat" {
+  count                              = terraform.workspace == "dev" ? 1 : 0
   project                            = var.project_id
   name                               = "shared-gke-nat"
-  router                             = google_compute_router.shared_router.name
+  router                             = google_compute_router.shared_router[0].name
   region                             = var.region
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"


### PR DESCRIPTION
Changes:
- Shared network only created in 'dev' workspace to avoid conflicts
- Other workspaces use data source to reference existing network
- Added local.shared_network_name for conditional network reference
- Updated outputs to handle both module and data source scenarios

Apply order: dev workspace must be applied first to create shared infrastructure, then other workspaces can reference it.

https://claude.ai/code/session_011CUyCZTyJkidQosuhSRALT