### PR TITLE
Add platform documentation and fix NAP disk defaults

### DIFF
--- a/cicd/cloudbuild-plan.yaml
+++ b/cicd/cloudbuild-plan.yaml
@@ -91,7 +91,7 @@ steps:
     json_file="/workspace/tfplan_gitops.json"
     if [ -f "$json_file" ]; then
         echo "=== Plan Summary: gitops ==="
-        tf-summarize -tree "$json_file"
+        tf-summarize "$json_file"
         echo "============================"
     else
         echo "No changes detected for gitops"
@@ -163,7 +163,7 @@ steps:
     json_file="/workspace/tfplan_dev.json"
     if [ -f "$json_file" ]; then
         echo "=== Plan Summary: dev ==="
-        tf-summarize -tree "$json_file"
+        tf-summarize "$json_file"
         echo "========================="
     else
         echo "No changes detected for dev"
@@ -235,7 +235,7 @@ steps:
     json_file="/workspace/tfplan_staging.json"
     if [ -f "$json_file" ]; then
         echo "=== Plan Summary: staging ==="
-        tf-summarize -tree "$json_file"
+        tf-summarize "$json_file"
         echo "============================="
     else
         echo "No changes detected for staging"

--- a/cicd/cloudbuild-plan.yaml
+++ b/cicd/cloudbuild-plan.yaml
@@ -72,12 +72,31 @@ steps:
             echo "STATUS: No changes detected"
         else
             echo "STATUS: Changes detected"
+            terraform show -json /workspace/tfplan_${workspace_name} > /workspace/tfplan_${workspace_name}.json
         fi
     else
         echo "✗ Plan failed for workspace: $workspace_name"
         exit 1
     fi
   timeout: 600s
+
+- id: summarize-gitops-plan
+  name: ghcr.io/dineshba/tf-summarize:latest
+  waitFor:
+  - plan-gitops
+  entrypoint: /bin/sh
+  args:
+  - -c
+  - |
+    json_file="/workspace/tfplan_gitops.json"
+    if [ -f "$json_file" ]; then
+        echo "=== Plan Summary: gitops ==="
+        tf-summarize -tree "$json_file"
+        echo "============================"
+    else
+        echo "No changes detected for gitops"
+    fi
+  timeout: 120s
 
 ###################
 # DEV WORKSPACE - PLAN
@@ -125,12 +144,31 @@ steps:
             echo "STATUS: No changes detected"
         else
             echo "STATUS: Changes detected"
+            terraform show -json /workspace/tfplan_${workspace_name} > /workspace/tfplan_${workspace_name}.json
         fi
     else
         echo "✗ Plan failed for workspace: $workspace_name"
         exit 1
     fi
   timeout: 600s
+
+- id: summarize-dev-plan
+  name: ghcr.io/dineshba/tf-summarize:latest
+  waitFor:
+  - plan-dev
+  entrypoint: /bin/sh
+  args:
+  - -c
+  - |
+    json_file="/workspace/tfplan_dev.json"
+    if [ -f "$json_file" ]; then
+        echo "=== Plan Summary: dev ==="
+        tf-summarize -tree "$json_file"
+        echo "========================="
+    else
+        echo "No changes detected for dev"
+    fi
+  timeout: 120s
 
 ###################
 # STAGING WORKSPACE - PLAN
@@ -178,12 +216,31 @@ steps:
             echo "STATUS: No changes detected"
         else
             echo "STATUS: Changes detected"
+            terraform show -json /workspace/tfplan_${workspace_name} > /workspace/tfplan_${workspace_name}.json
         fi
     else
         echo "✗ Plan failed for workspace: $workspace_name"
         exit 1
     fi
   timeout: 600s
+
+- id: summarize-staging-plan
+  name: ghcr.io/dineshba/tf-summarize:latest
+  waitFor:
+  - plan-staging
+  entrypoint: /bin/sh
+  args:
+  - -c
+  - |
+    json_file="/workspace/tfplan_staging.json"
+    if [ -f "$json_file" ]; then
+        echo "=== Plan Summary: staging ==="
+        tf-summarize -tree "$json_file"
+        echo "============================="
+    else
+        echo "No changes detected for staging"
+    fi
+  timeout: 120s
 
 ###################
 # SUMMARY & PR COMMENT
@@ -193,9 +250,9 @@ steps:
   name: alpine:3.18
   entrypoint: /bin/sh
   waitFor:
-  - plan-gitops
-  - plan-dev
-  - plan-staging
+  - summarize-gitops-plan
+  - summarize-dev-plan
+  - summarize-staging-plan
   args:
   - -c
   - |

--- a/cicd/cloudbuild-test.yaml
+++ b/cicd/cloudbuild-test.yaml
@@ -23,7 +23,7 @@ steps:
   timeout: 60s
 
 # Test Trivy filesystem scan
-- name: aquasec/trivy:latest
+- name: ghcr.io/aquasecurity/trivy:latest
   id: trivy-fs-scan
   entrypoint: trivy
   args:
@@ -40,7 +40,7 @@ steps:
   timeout: 300s
 
 # Test Trivy config scan
-- name: aquasec/trivy:latest
+- name: ghcr.io/aquasecurity/trivy:latest
   id: trivy-config-scan
   entrypoint: trivy
   args:

--- a/cicd/cloudbuild.yaml
+++ b/cicd/cloudbuild.yaml
@@ -181,7 +181,7 @@ steps:
     json_file="/workspace/$BUILD_ID/tfplan_gitops.json"
     if [ -f "$json_file" ]; then
         echo "=== Plan Summary: gitops ==="
-        tf-summarize -tree "$json_file"
+        tf-summarize "$json_file"
         echo "============================"
     else
         echo "No changes detected for gitops"
@@ -306,7 +306,7 @@ steps:
     json_file="/workspace/$BUILD_ID/tfplan_dev.json"
     if [ -f "$json_file" ]; then
         echo "=== Plan Summary: dev ==="
-        tf-summarize -tree "$json_file"
+        tf-summarize "$json_file"
         echo "========================="
     else
         echo "No changes detected for dev"
@@ -431,7 +431,7 @@ steps:
     json_file="/workspace/$BUILD_ID/tfplan_staging.json"
     if [ -f "$json_file" ]; then
         echo "=== Plan Summary: staging ==="
-        tf-summarize -tree "$json_file"
+        tf-summarize "$json_file"
         echo "============================="
     else
         echo "No changes detected for staging"

--- a/cicd/cloudbuild.yaml
+++ b/cicd/cloudbuild.yaml
@@ -159,7 +159,10 @@ steps:
         case $plan_exit_code in
             0) echo "No changes detected" ;;
             1) echo "Plan failed"; exit 1 ;;
-            2) echo "Plan succeeded with changes" ;;
+            2)
+                echo "Plan succeeded with changes"
+                terraform show -json "$plan_file" > "${plan_file}.json"
+                ;;
         esac
         exit 0
     else
@@ -167,10 +170,28 @@ steps:
     fi
   timeout: 1200s
 
+- id: summarize-gitops
+  name: ghcr.io/dineshba/tf-summarize:latest
+  waitFor:
+  - plan-gitops
+  entrypoint: /bin/sh
+  args:
+  - -c
+  - |
+    json_file="/workspace/$BUILD_ID/tfplan_gitops.json"
+    if [ -f "$json_file" ]; then
+        echo "=== Plan Summary: gitops ==="
+        tf-summarize -tree "$json_file"
+        echo "============================"
+    else
+        echo "No changes detected for gitops"
+    fi
+  timeout: 120s
+
 - id: apply-gitops
   name: hashicorp/terraform:1.14
   waitFor:
-  - plan-gitops
+  - summarize-gitops
   entrypoint: /bin/sh
   secretEnv:
   - GOOGLE_CREDENTIALS
@@ -263,7 +284,10 @@ steps:
         case $plan_exit_code in
             0) echo "No changes detected" ;;
             1) echo "Plan failed"; exit 1 ;;
-            2) echo "Plan succeeded with changes" ;;
+            2)
+                echo "Plan succeeded with changes"
+                terraform show -json "$plan_file" > "${plan_file}.json"
+                ;;
         esac
         exit 0
     else
@@ -271,10 +295,28 @@ steps:
     fi
   timeout: 1200s
 
+- id: summarize-dev
+  name: ghcr.io/dineshba/tf-summarize:latest
+  waitFor:
+  - plan-dev
+  entrypoint: /bin/sh
+  args:
+  - -c
+  - |
+    json_file="/workspace/$BUILD_ID/tfplan_dev.json"
+    if [ -f "$json_file" ]; then
+        echo "=== Plan Summary: dev ==="
+        tf-summarize -tree "$json_file"
+        echo "========================="
+    else
+        echo "No changes detected for dev"
+    fi
+  timeout: 120s
+
 - id: apply-dev
   name: hashicorp/terraform:1.14
   waitFor:
-  - plan-dev
+  - summarize-dev
   entrypoint: /bin/sh
   secretEnv:
   - GOOGLE_CREDENTIALS
@@ -367,7 +409,10 @@ steps:
         case $plan_exit_code in
             0) echo "No changes detected" ;;
             1) echo "Plan failed"; exit 1 ;;
-            2) echo "Plan succeeded with changes" ;;
+            2)
+                echo "Plan succeeded with changes"
+                terraform show -json "$plan_file" > "${plan_file}.json"
+                ;;
         esac
         exit 0
     else
@@ -375,10 +420,28 @@ steps:
     fi
   timeout: 1200s
 
+- id: summarize-staging
+  name: ghcr.io/dineshba/tf-summarize:latest
+  waitFor:
+  - plan-staging
+  entrypoint: /bin/sh
+  args:
+  - -c
+  - |
+    json_file="/workspace/$BUILD_ID/tfplan_staging.json"
+    if [ -f "$json_file" ]; then
+        echo "=== Plan Summary: staging ==="
+        tf-summarize -tree "$json_file"
+        echo "============================="
+    else
+        echo "No changes detected for staging"
+    fi
+  timeout: 120s
+
 - id: apply-staging
   name: hashicorp/terraform:1.14
   waitFor:
-  - plan-staging
+  - summarize-staging
   entrypoint: /bin/sh
   secretEnv:
   - GOOGLE_CREDENTIALS

--- a/cicd/cloudbuild.yaml
+++ b/cicd/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
   timeout: 60s
 
 # Security Scanning Steps
-- name: aquasec/trivy:latest
+- name: ghcr.io/aquasecurity/trivy:latest
   id: trivy-fs-scan
   entrypoint: trivy
   args:
@@ -35,7 +35,7 @@ steps:
   - 'TRIVY_CACHE_DIR=/workspace/.trivy-cache'
   timeout: 300s
 
-- name: aquasec/trivy:latest
+- name: ghcr.io/aquasecurity/trivy:latest
   id: trivy-config-scan
   entrypoint: trivy
   args:

--- a/docs/ADDING-A-CLUSTER.md
+++ b/docs/ADDING-A-CLUSTER.md
@@ -1,0 +1,259 @@
+# Adding a New Cluster
+
+This guide walks through adding a fourth cluster (e.g., `prod`) to the platform. The process involves five areas: networking, Terraform locals, GKE provisioning, ArgoCD registration, and application definitions.
+
+---
+
+## Overview of Changes
+
+| Step | What | File(s) |
+|------|------|---------|
+| 1 | Add subnet and secondary ranges | `shared-network.tf` |
+| 2 | Add workspace to locals | `locals.tf` |
+| 3 | Terraform creates the cluster | `gke.tf` (no change needed — uses `terraform.workspace`) |
+| 4 | Add cluster to ArgoCD cluster map | `locals.tf` |
+| 5 | ESO creates cluster secret | `eso.tf` (no change needed — driven by `local.eso_managed_clusters`) |
+| 6 | Create app definitions directory | `gke-applications/prod/` |
+| 7 | Create Terraform workspace | CLI |
+| 8 | Apply | CLI |
+
+---
+
+## Step 1: Add a Subnet
+
+Edit `shared-network.tf`. In the `subnets` list of the `module "shared-network"` block, add a new entry:
+
+```hcl
+{
+  subnet_name           = "gke-subnet-prod"
+  subnet_ip             = "10.40.0.0/17"
+  subnet_region         = var.region
+  subnet_private_access = true
+},
+```
+
+In the `secondary_ranges` map, add:
+
+```hcl
+"gke-subnet-prod" = [
+  {
+    range_name    = "prod-pods"
+    ip_cidr_range = "172.19.0.0/18"
+  },
+  {
+    range_name    = "prod-services"
+    ip_cidr_range = "172.19.64.0/18"
+  },
+]
+```
+
+Choose non-overlapping CIDRs. Existing ranges:
+
+| Cluster | Node | Pods | Services |
+|---------|------|------|----------|
+| dev | 10.10.0.0/17 | 172.16.0.0/18 | 172.16.64.0/18 |
+| staging | 10.20.0.0/17 | 172.17.0.0/18 | 172.17.64.0/18 |
+| gitops | 10.30.0.0/17 | 172.18.0.0/18 | 172.18.64.0/18 |
+
+---
+
+## Step 2: Update locals.tf
+
+### Add to `master_cidr_offsets`
+
+```hcl
+master_cidr_offsets = {
+  dev     = "0"
+  staging = "1"
+  gitops  = "2"
+  prod    = "3"   # ← add this
+}
+```
+
+This determines the master plane CIDR: `172.19.3.0/28`.
+
+### Add `prod` to `cluster_types` if you want Terraform to loop over it
+
+```hcl
+cluster_types = toset(["gitops", "dev", "staging", "prod"])
+```
+
+Note: `cluster_types` is currently only used if you add loops in the future. The cluster itself is provisioned using `terraform.workspace`, so the workspace name IS the cluster type.
+
+---
+
+## Step 3: GKE Cluster
+
+No changes to `gke.tf` are required. The cluster name, subnet, and master CIDR are all derived from `terraform.workspace`. When you create a `prod` workspace and apply, it automatically provisions `prod-cluster` on `gke-subnet-prod` with master CIDR `172.19.3.0/28`.
+
+To customize node pools for prod (e.g., larger machines), create a workspace-conditional block:
+
+```hcl
+node_pools = terraform.workspace == "prod" ? [
+  {
+    name         = "node-pool-01"
+    machine_type = "e2-standard-8"   # larger for prod
+    min_count    = 2
+    max_count    = 10
+    spot         = false
+    disk_size_gb = 50
+    disk_type    = "pd-ssd"
+    image_type   = "COS_CONTAINERD"
+    auto_repair  = true
+    auto_upgrade = true
+    preemptible  = false
+    initial_node_count = 2
+  }
+] : [
+  # ... existing node pool definition
+]
+```
+
+---
+
+## Step 4: Register with ArgoCD
+
+Edit `locals.tf` to include `prod` in the ArgoCD cluster map. Currently `argocd_clusters` is built dynamically from data sources. To add prod:
+
+### 4a. Add a data source for the prod cluster in `argocd.tf`
+
+```hcl
+data "google_container_cluster" "prod" {
+  count    = terraform.workspace == "gitops" ? 1 : 0
+  name     = "prod-cluster"
+  location = var.region
+  project  = var.project_id
+}
+```
+
+Add it to the `remote` data source list (or add it explicitly like gitops cluster). The existing pattern in `argocd.tf` uses a dynamic API call to discover clusters — prod will be discovered automatically once it exists.
+
+### 4b. The `eso_managed_clusters` local already handles this
+
+Because `eso_managed_clusters` filters `argocd_clusters` to exclude `gitops`, any cluster you add to `argocd_clusters` (dev, staging, prod, etc.) automatically gets:
+- A GCP Secret Manager secret (`argocd-cluster-prod`)
+- An ExternalSecret to sync the credentials to ArgoCD
+
+No changes to `eso.tf` are needed.
+
+---
+
+## Step 5: Create Application Definitions
+
+Create the directory and populate it with app definitions:
+
+```bash
+mkdir gke-applications/prod
+```
+
+Start by copying from an existing environment:
+
+```bash
+cp gke-applications/staging/*.yaml gke-applications/prod/
+```
+
+Update `cluster_env` in every file:
+
+```bash
+# On macOS
+sed -i '' 's/cluster_env: staging/cluster_env: prod/' gke-applications/prod/*.yaml
+
+# On Linux
+sed -i 's/cluster_env: staging/cluster_env: prod/' gke-applications/prod/*.yaml
+```
+
+Then review each file and adjust versions, replica counts, and resource requests as appropriate for prod.
+
+**Important naming rules in each YAML:**
+
+```yaml
+name: my-app          # Must be unique within the cluster; becomes the Helm release name
+chart: my-chart
+repoURL: https://...
+targetRevision: "1.2.3"
+namespace: my-ns      # Namespace to deploy into; created automatically by ArgoCD
+cluster_env: prod     # Informational label only — does not affect routing
+```
+
+---
+
+## Step 6: Create and Apply the Workspace
+
+```bash
+# Initialize (only needed once)
+terraform init -upgrade
+
+# Create workspace
+terraform workspace new prod
+
+# Plan — review what will be created
+terraform plan -out prod.tfplan
+
+# Apply
+terraform apply prod.tfplan
+```
+
+Apply order:
+1. Apply `gitops` workspace first (creates shared network and adds prod to ArgoCD)
+2. Apply `prod` workspace (creates the cluster, writes credentials to Secret Manager)
+3. ESO syncs credentials within 1 hour; ArgoCD then deploys all apps in `gke-applications/prod/`
+
+To force ESO to sync immediately (without waiting 1 hour):
+
+```bash
+# Connect to gitops cluster
+gcloud container clusters get-credentials gitops-cluster --region us-central1 --project cluster-dreams
+
+# Annotate the ExternalSecret to trigger immediate refresh
+kubectl annotate externalsecret prod-cluster-secret \
+  force-sync=$(date +%s) \
+  -n argocd --overwrite
+```
+
+---
+
+## Step 7: Update CI/CD Pipelines (if scheduled destroy/recreate is wanted)
+
+If prod should also be destroyed nightly:
+
+Edit `cicd/cloudbuild-destroy.yaml` and add a destroy step for prod (follow the existing pattern for dev/staging).
+
+Edit `cicd/cloudbuild-create.yaml` and add a create step for prod.
+
+If prod should run 24/7, no CI/CD changes are needed.
+
+---
+
+## Step 8: Verify
+
+```bash
+# Connect to gitops cluster
+gcloud container clusters get-credentials gitops-cluster --region us-central1 --project cluster-dreams
+
+# Check that ArgoCD registered the new cluster
+kubectl get secret -n argocd -l argocd.argoproj.io/secret-type=cluster
+
+# Check that ApplicationSet was created
+kubectl get applicationset -n argocd
+
+# Check that apps are being deployed
+kubectl get applications -n argocd | grep prod
+
+# Connect to prod cluster and verify workloads
+gcloud container clusters get-credentials prod-cluster --region us-central1 --project cluster-dreams
+kubectl get pods -A
+```
+
+---
+
+## Checklist
+
+- [ ] Subnet added to `shared-network.tf` with unique CIDRs
+- [ ] Master CIDR offset added to `locals.tf`
+- [ ] `gke-applications/prod/` directory created with app definitions
+- [ ] `cluster_env` updated to `prod` in all YAML files
+- [ ] Terraform workspace `prod` created
+- [ ] Gitops workspace applied (to create Secret Manager secret + ExternalSecret)
+- [ ] Prod workspace applied (to create cluster + write credentials to Secret Manager)
+- [ ] ArgoCD shows prod cluster as registered
+- [ ] All apps show Synced/Healthy in ArgoCD

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,192 @@
+# Architecture Overview
+
+This document describes the design of the GKE multi-cluster GitOps platform.
+
+---
+
+## High-Level Design
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ GitHub (muyisbox/gke)                                               │
+│  ├─ Terraform IaC (*.tf)                                            │
+│  ├─ App definitions (gke-applications/{cluster}/*.yaml)             │
+│  └─ CI/CD pipelines (cicd/cloudbuild*.yaml)                        │
+└─────────────────────┬───────────────────────────────────────────────┘
+                      │  Push/PR triggers
+                      ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ Google Cloud Build                                                  │
+│  ├─ PR: plan all workspaces (cloudbuild-plan.yaml)                 │
+│  ├─ Merge to master: apply all workspaces (cloudbuild.yaml)        │
+│  ├─ 2 AM EST: destroy dev+staging (cloudbuild-destroy.yaml)        │
+│  └─ 10 AM EST: recreate dev+staging (cloudbuild-create.yaml)       │
+└─────────────────────┬───────────────────────────────────────────────┘
+                      │  Provisions
+                      ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ GCP Project: cluster-dreams  /  Region: us-central1                 │
+│                                                                     │
+│  Shared VPC: shared-gke-network                                     │
+│  ├─ gke-subnet-gitops   (10.30.0.0/17)                             │
+│  ├─ gke-subnet-dev      (10.10.0.0/17)                             │
+│  └─ gke-subnet-staging  (10.20.0.0/17)                             │
+│                                                                     │
+│  ┌──────────────────┐  ┌──────────────┐  ┌──────────────────┐     │
+│  │  gitops-cluster  │  │ dev-cluster  │  │ staging-cluster  │     │
+│  │  (Hub / Control) │  │   (Spoke)    │  │    (Spoke)       │     │
+│  │                  │  │              │  │                  │     │
+│  │  ArgoCD          │──▶ All apps     │  │  All apps        │     │
+│  │  ESO             │──▶              │  │                  │     │
+│  │  Monitoring      │  │              │  │                  │     │
+│  └──────────────────┘  └──────────────┘  └──────────────────┘     │
+│                                                                     │
+│  GCP Secret Manager                                                 │
+│  ├─ argocd-cluster-dev      (cluster endpoint + CA cert)           │
+│  └─ argocd-cluster-staging  (cluster endpoint + CA cert)           │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Terraform Workspaces
+
+Each environment is a separate Terraform workspace sharing a single GCS state bucket.
+
+| Workspace | Cluster | State Key |
+|-----------|---------|-----------|
+| `gitops` | gitops-cluster | `terraform/state/gitops` |
+| `dev` | dev-cluster | `terraform/state/dev` |
+| `staging` | staging-cluster | `terraform/state/staging` |
+
+**Apply order matters**: `gitops` workspace must be applied first (creates the shared VPC, Cloud NAT, and ArgoCD). Dev and staging can then be applied in any order.
+
+---
+
+## Networking
+
+All clusters share one VPC (`shared-gke-network`) with one Cloud Router and one Cloud NAT — avoiding per-cluster NAT charges.
+
+| Cluster | Node CIDR | Pod CIDR | Service CIDR | Master CIDR |
+|---------|-----------|----------|--------------|-------------|
+| dev | 10.10.0.0/17 | 172.16.0.0/18 | 172.16.64.0/18 | 172.19.0.0/28 |
+| staging | 10.20.0.0/17 | 172.17.0.0/18 | 172.17.64.0/18 | 172.19.1.0/28 |
+| gitops | 10.30.0.0/17 | 172.18.0.0/18 | 172.18.64.0/18 | 172.19.2.0/28 |
+
+All clusters are private (nodes have no public IPs). The control plane endpoint is public but protected by GCP auth.
+
+---
+
+## GitOps Flow (Hub-Spoke ArgoCD)
+
+```
+GitHub repo (gke-applications/{cluster}/*.yaml)
+       │
+       │  Git generator polls for new/changed files
+       ▼
+ArgoCD ApplicationSet (running on gitops-cluster)
+       │
+       │  Creates one Application per YAML file found
+       ▼
+ArgoCD Application
+       │
+       │  Deploys Helm chart to target cluster
+       ▼
+ dev-cluster / staging-cluster / gitops-cluster
+```
+
+1. Each file in `gke-applications/{cluster}/` defines one application.
+2. The `{cluster}-apps` ApplicationSet watches that directory.
+3. When a file is added/changed, ArgoCD creates/updates the corresponding Application.
+4. ArgoCD connects to the target cluster using credentials from Kubernetes secrets (populated by ESO for dev/staging, or directly for gitops).
+
+---
+
+## Secret Management (ESO)
+
+Terraform populates GCP Secret Manager with cluster credentials. ESO reads those secrets and creates ArgoCD cluster registration secrets inside the gitops cluster.
+
+```
+Terraform apply (gitops workspace)
+  └─▶ Writes cluster endpoint + CA cert to GCP Secret Manager
+           │
+           ▼
+External Secrets Operator (on gitops-cluster)
+  └─▶ Reads Secret Manager via Workload Identity
+  └─▶ Creates K8s secret in argocd namespace (label: argocd.argoproj.io/secret-type=cluster)
+           │
+           ▼
+ArgoCD detects cluster secret → registers cluster → deploys apps
+```
+
+**Why this design**: Dev and staging clusters are destroyed nightly and recreated in the morning. Their endpoints change. Terraform writes the new endpoint to Secret Manager, ESO syncs it to ArgoCD (within 1 hour), and ArgoCD reconnects automatically.
+
+---
+
+## Node Configuration
+
+All clusters use the same node pool spec:
+
+| Setting | Value |
+|---------|-------|
+| Machine type | e2-standard-4 (4 vCPU, 16 GB) |
+| Disk | 30 GB pd-ssd |
+| Image | COS_CONTAINERD |
+| Spot/Preemptible | No (regular VMs for stability) |
+| Min nodes | 1 |
+| Max nodes | 4 (per pool) |
+| Autoscaler profile | OPTIMIZE_UTILIZATION |
+
+Node Auto-Provisioning (NAP) is enabled, allowing GKE to provision nodes of different types when workloads require it.
+
+---
+
+## Cost Optimization
+
+Dev and staging clusters are destroyed every night at 2 AM EST and recreated at 10 AM EST by Cloud Scheduler → Cloud Build triggers. Only gitops runs 24/7 (it owns the shared network and ArgoCD).
+
+Estimated savings: ~67% on dev/staging compute costs (16 hours off per day).
+
+---
+
+## Applications Deployed Per Cluster
+
+All clusters run the same base stack:
+
+| Application | Chart | Namespace | Purpose |
+|-------------|-------|-----------|---------|
+| external-secrets | external-secrets | external-secrets | Syncs GCP secrets to K8s |
+| cert-manager | cert-manager | cert-manager | TLS certificate management |
+| istio-base | base | istio-system | Istio CRDs |
+| istiod | istiod | istio-system | Istio control plane |
+| istio-gateway | gateway | istio-gateways | Ingress gateway |
+| prometheus-monitoring | kube-prometheus-stack | monitoring | Metrics + Grafana + Alertmanager |
+| loki | loki | logging | Log aggregation |
+| kiali | kiali | monitoring | Istio topology visualization |
+| argo-rollouts | argo-rollouts | argo-rollouts | Progressive delivery |
+| external-dns | external-dns | external-dns | Automatic DNS records |
+| reloader | reloader | reloader | Restart pods on ConfigMap/Secret changes |
+| vpa | vertical-pod-autoscaler | kube-system | Vertical pod autoscaling |
+
+Dev cluster also runs `bookinfo` (Istio demo app).
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `gke.tf` | GKE cluster definition (same for all workspaces) |
+| `shared-network.tf` | VPC, subnets, Cloud NAT (created in gitops only) |
+| `argocd.tf` | ArgoCD Helm release + cluster secrets |
+| `eso.tf` | ESO GCP SA, Secret Manager secrets, CRDs, ClusterSecretStore, ExternalSecrets |
+| `locals.tf` | Cluster maps, chart configs, template rendering |
+| `variables.tf` | Variable definitions |
+| `values.auto.tfvars` | Variable values (project ID, region, chart versions) |
+| `templates/apps-values.yaml` | Helm values template for ArgoCD ApplicationSets |
+| `templates/argocd-values.yaml` | Helm values for ArgoCD itself |
+| `gke-applications/{cluster}/*.yaml` | Per-cluster application definitions |
+| `cicd/cloudbuild.yaml` | Main apply pipeline |
+| `cicd/cloudbuild-plan.yaml` | PR plan pipeline |
+| `cicd/cloudbuild-destroy.yaml` | Nightly destroy pipeline |
+| `cicd/cloudbuild-create.yaml` | Morning recreate pipeline |

--- a/docs/ONBOARDING-AN-APP.md
+++ b/docs/ONBOARDING-AN-APP.md
@@ -1,0 +1,296 @@
+# Onboarding a New Application
+
+Applications are deployed via ArgoCD ApplicationSets using a Git file generator. To add a new app, you create a single YAML file in the appropriate cluster directory. No Terraform changes are required.
+
+---
+
+## How It Works
+
+```
+gke-applications/
+├── dev/
+│   └── my-app.yaml       ← you create this file
+├── staging/
+│   └── my-app.yaml
+└── gitops/
+    └── my-app.yaml       (if also needed on the hub cluster)
+```
+
+ArgoCD's `{cluster}-apps` ApplicationSet watches `gke-applications/{cluster}/*.yaml` on the `master` branch. When you push a new YAML file, ArgoCD automatically creates an Application and begins deploying the Helm chart.
+
+---
+
+## Application File Format
+
+Every application file must have these required fields:
+
+```yaml
+name: my-app                               # Unique within the cluster; becomes the Helm release name
+chart: my-chart-name                       # Helm chart name in the repo
+repoURL: https://charts.example.com        # Helm chart repository URL
+targetRevision: "1.2.3"                   # Chart version (pin to exact version in prod)
+namespace: my-namespace                    # Target namespace (created automatically)
+cluster_env: dev                           # Label only — use dev, staging, or gitops
+```
+
+### With Helm Values
+
+```yaml
+name: my-app
+chart: my-chart-name
+repoURL: https://charts.example.com
+targetRevision: "1.2.3"
+namespace: my-namespace
+cluster_env: dev
+helm:
+  values:
+    replicaCount: 2
+    image:
+      tag: "v1.0.0"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+```
+
+### With Helm Values Files
+
+```yaml
+name: my-app
+chart: my-chart-name
+repoURL: https://charts.example.com
+targetRevision: "1.2.3"
+namespace: my-namespace
+cluster_env: dev
+helm:
+  valueFiles:
+    - values.yaml
+    - values-dev.yaml
+```
+
+Note: `valueFiles` paths are relative to the chart root in the Helm repository.
+
+---
+
+## Step-by-Step: Add an App to Dev and Staging
+
+### 1. Create the application file
+
+```bash
+# Create for dev
+cat > gke-applications/dev/my-app.yaml << 'EOF'
+name: my-app
+chart: my-chart
+repoURL: https://charts.example.com
+targetRevision: "1.0.0"
+namespace: my-app
+cluster_env: dev
+helm:
+  values:
+    replicaCount: 1
+    serviceMonitor:
+      enabled: true
+      labels:
+        release: prometheus-monitoring
+EOF
+
+# Copy and adjust for staging
+cp gke-applications/dev/my-app.yaml gke-applications/staging/my-app.yaml
+sed -i '' 's/cluster_env: dev/cluster_env: staging/' gke-applications/staging/my-app.yaml
+# Update replica count or any staging-specific values
+```
+
+### 2. Commit and push
+
+```bash
+git add gke-applications/
+git commit -m "Add my-app to dev and staging clusters"
+git push origin master
+```
+
+### 3. Verify in ArgoCD
+
+```bash
+# Connect to gitops cluster
+gcloud container clusters get-credentials gitops-cluster \
+  --region us-central1 --project cluster-dreams
+
+# Watch for the new Application objects to appear
+kubectl get applications -n argocd | grep my-app
+
+# Check sync status
+kubectl describe application my-app-dev -n argocd
+kubectl describe application my-app-staging -n argocd
+```
+
+Or use the ArgoCD UI (port-forward to access it):
+
+```bash
+kubectl port-forward svc/argo-cd-argocd-server 8080:443 -n argocd
+# Open https://localhost:8080
+```
+
+---
+
+## Real-World Examples
+
+### cert-manager (minimal config)
+
+```yaml
+name: cert-manager
+chart: cert-manager
+repoURL: https://charts.jetstack.io
+targetRevision: "1.20.0"
+namespace: cert-manager
+cluster_env: dev
+helm:
+  values:
+    crds:
+      enabled: true
+    replicaCount: 2
+    prometheus:
+      enabled: true
+      servicemonitor:
+        enabled: true
+        labels:
+          release: prometheus-monitoring
+```
+
+### External Secrets Operator (with Workload Identity annotation)
+
+```yaml
+name: external-secrets
+chart: external-secrets
+repoURL: https://charts.external-secrets.io
+targetRevision: "2.1.0"
+namespace: external-secrets
+cluster_env: dev
+helm:
+  values:
+    crds:
+      install: true
+    replicaCount: 2
+    serviceAccount:
+      create: true
+      annotations:
+        iam.gke.io/gcp-service-account: eso-controller@cluster-dreams.iam.gserviceaccount.com
+    serviceMonitor:
+      enabled: true
+      labels:
+        release: prometheus-monitoring
+```
+
+### Loki (SingleBinary mode for filesystem storage)
+
+```yaml
+name: loki-stack
+chart: loki
+repoURL: https://grafana.github.io/helm-charts
+targetRevision: "6.30.1"
+namespace: logging
+cluster_env: dev
+helm:
+  values:
+    deploymentMode: SingleBinary
+    loki:
+      auth_enabled: false
+      storage:
+        type: filesystem
+    singleBinary:
+      replicas: 1
+    read:
+      replicas: 0
+    write:
+      replicas: 0
+    backend:
+      replicas: 0
+```
+
+---
+
+## Naming Conventions
+
+| Field | Convention | Example |
+|-------|-----------|---------|
+| `name` | kebab-case, descriptive | `cert-manager`, `prometheus-monitoring` |
+| `namespace` | matches app name or team domain | `cert-manager`, `monitoring`, `logging` |
+| `cluster_env` | must match the directory name | `dev`, `staging`, `gitops` |
+| File name | same as `name` field | `cert-manager.yaml` |
+
+---
+
+## Handling Namespace-Sensitive Apps
+
+Some apps should never run in `kube-system`. The platform does not use `managedNamespaceMetadata`, so namespaces are created clean without any Istio labels. If your app needs to disable sidecar injection in its namespace, add an annotation at the app level:
+
+```yaml
+helm:
+  values:
+    podAnnotations:
+      sidecar.istio.io/inject: "false"
+```
+
+Or for cluster-wide resources (webhooks, operators) that conflict with Istio, annotate the namespace separately using a raw Kubernetes manifest approach (create a separate app with `chart: raw` or use an init job).
+
+---
+
+## Updating an Existing App
+
+To change an app's chart version or values:
+
+1. Edit the YAML file in the relevant `gke-applications/{cluster}/` directory.
+2. Commit and push.
+3. ArgoCD detects the change within the poll interval (default: 3 minutes) and updates the Application.
+4. Because `selfHeal: true` and `prune: true` are set, ArgoCD will automatically sync.
+
+To pin a specific Git revision for the ApplicationSet (instead of `master`), change the `revision` field in `templates/apps-values.yaml` and re-apply via Terraform.
+
+---
+
+## Removing an App
+
+1. Delete the YAML file from `gke-applications/{cluster}/`.
+2. Commit and push.
+3. ArgoCD detects the file is gone, deletes the Application, and prunes all resources it deployed (because `prune: true` is set in the sync policy).
+
+```bash
+git rm gke-applications/dev/my-app.yaml
+git commit -m "Remove my-app from dev cluster"
+git push origin master
+```
+
+---
+
+## Troubleshooting
+
+### App stuck in Unknown state
+
+Check if the required fields are present:
+
+```bash
+kubectl describe application my-app-dev -n argocd | grep -A5 "Status:"
+```
+
+Common causes:
+- Missing `repoURL` or `chart` — always required
+- `helm.values` present but `templatePatch` not applying — check that the YAML is valid (no tabs, proper indentation)
+
+### App OutOfSync but not auto-syncing
+
+ArgoCD may have hit an error during sync. Check:
+
+```bash
+kubectl describe application my-app-dev -n argocd | grep -A20 "Conditions:"
+```
+
+Common causes:
+- Chart version doesn't exist in the repo
+- Helm values reference a key that doesn't exist in the chart's `values.yaml`
+- Resource already exists in the cluster with a different owner (use `ServerSideApply=true` sync option, already enabled by default)
+
+### Namespace not created
+
+`CreateNamespace=true` is set in the default sync policy. If the namespace isn't being created, the app is likely in an error state before the namespace creation step. Check the application events.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,390 @@
+# Runbook: Common Operations
+
+This runbook covers frequent operational tasks: connecting to clusters, running Terraform, debugging ArgoCD, and recovering from failures.
+
+---
+
+## Setup
+
+### Load aliases (run once per terminal session)
+
+```bash
+source scripts/gcloud-aliases.sh
+```
+
+### Connect to a cluster
+
+```bash
+# Gitops (hub cluster)
+gcloud container clusters get-credentials gitops-cluster --region us-central1 --project cluster-dreams
+
+# Dev
+gcloud container clusters get-credentials dev-cluster --region us-central1 --project cluster-dreams
+
+# Staging
+gcloud container clusters get-credentials staging-cluster --region us-central1 --project cluster-dreams
+
+# Using alias
+gke-connect gitops-cluster
+```
+
+---
+
+## Terraform Operations
+
+### Initialize
+
+```bash
+terraform init -upgrade
+```
+
+### Switch workspace
+
+```bash
+terraform workspace select gitops   # or dev / staging
+```
+
+### Plan and apply a specific workspace
+
+```bash
+terraform workspace select dev
+terraform plan -out dev.tfplan
+terraform apply dev.tfplan
+```
+
+### Apply all workspaces (same order as CI/CD)
+
+```bash
+for ws in gitops dev staging; do
+  terraform workspace select $ws
+  terraform plan -out ${ws}.tfplan
+  terraform apply ${ws}.tfplan
+done
+```
+
+### Refresh state without applying
+
+```bash
+terraform refresh
+```
+
+### Import a resource into state (e.g., after a node pool was recreated outside Terraform)
+
+```bash
+# Example: re-import dev node pool
+terraform workspace select dev
+terraform import \
+  'module.gke.google_container_node_pool.pools["node-pool-01"]' \
+  projects/cluster-dreams/locations/us-central1/clusters/dev-cluster/nodePools/node-pool-01
+```
+
+### Force-unlock state (if a previous apply left a lock)
+
+```bash
+terraform workspace select dev
+terraform force-unlock LOCK_ID
+```
+
+---
+
+## ArgoCD Operations
+
+### Access the ArgoCD UI
+
+```bash
+# Connect to gitops cluster first
+gcloud container clusters get-credentials gitops-cluster --region us-central1 --project cluster-dreams
+
+# Port-forward
+kubectl port-forward svc/argo-cd-argocd-server 8080:443 -n argocd
+
+# Get the admin password
+kubectl get secret argocd-initial-admin-secret -n argocd -o jsonpath="{.data.password}" | base64 -d
+```
+
+Open https://localhost:8080 (ignore the self-signed cert warning).
+
+### List all applications
+
+```bash
+kubectl get applications -n argocd
+```
+
+### Force sync a specific app
+
+```bash
+kubectl patch application my-app-dev -n argocd \
+  --type merge \
+  -p '{"operation":{"sync":{"syncStrategy":{"apply":{"force":true}}}}}'
+```
+
+Or with the ArgoCD CLI:
+
+```bash
+argocd app sync my-app-dev --force
+```
+
+### Check why an app is OutOfSync
+
+```bash
+kubectl describe application my-app-dev -n argocd
+```
+
+### List registered clusters
+
+```bash
+kubectl get secret -n argocd -l argocd.argoproj.io/secret-type=cluster \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.data.name | @base64d}{"\n"}{end}'
+```
+
+### Force ESO to re-sync a cluster secret immediately
+
+```bash
+# Trigger immediate refresh (ESO normally refreshes every 1 hour)
+kubectl annotate externalsecret dev-cluster-secret \
+  force-sync=$(date +%s) \
+  -n argocd --overwrite
+```
+
+### Manually delete and recreate ArgoCD apps helm release (if Terraform state is out of sync)
+
+```bash
+terraform workspace select gitops
+terraform apply -replace='module.argocd-apps["gitops"].helm_release.this[0]'
+```
+
+---
+
+## Cluster Debugging
+
+### Check node status
+
+```bash
+kubectl get nodes -o wide
+```
+
+### Check why a node is NotReady
+
+```bash
+kubectl describe node NODE_NAME | grep -A 20 "Conditions:"
+```
+
+### Check kube-system pods (should never have istio.io/rev label)
+
+```bash
+# Verify kube-system does NOT have the istio label
+kubectl get namespace kube-system --show-labels
+
+# If it does, remove it immediately
+kubectl label namespace kube-system istio.io/rev-
+```
+
+### Check for pods stuck in Pending/Init state
+
+```bash
+kubectl get pods -A | grep -v Running | grep -v Completed
+kubectl describe pod POD_NAME -n NAMESPACE
+```
+
+### Check PVC status (storage issues)
+
+```bash
+kubectl get pvc -A
+kubectl describe pvc PVC_NAME -n NAMESPACE
+```
+
+---
+
+## Recovering from Common Failures
+
+### Nightly destroy left clusters in a broken state
+
+If Cloud Build destroy ran but create failed, clusters may be partially destroyed or in an inconsistent state.
+
+```bash
+# Check what exists
+gcloud container clusters list --project cluster-dreams --region us-central1
+
+# Re-run create pipeline manually
+gcloud builds triggers run terraform-create-scheduled \
+  --region us-central1 \
+  --project cluster-dreams
+
+# Or apply locally
+terraform workspace select dev
+terraform apply -auto-approve
+terraform workspace select staging
+terraform apply -auto-approve
+```
+
+### ArgoCD doesn't see a cluster after it was recreated
+
+1. Check if the Secret Manager secret was updated by Terraform:
+
+```bash
+gcloud secrets versions list argocd-cluster-dev --project cluster-dreams
+gcloud secrets versions access latest --secret argocd-cluster-dev --project cluster-dreams
+```
+
+2. Force ESO to refresh:
+
+```bash
+kubectl annotate externalsecret dev-cluster-secret \
+  force-sync=$(date +%s) -n argocd --overwrite
+```
+
+3. Check the ExternalSecret status:
+
+```bash
+kubectl get externalsecret dev-cluster-secret -n argocd -o yaml
+```
+
+4. Check if the ArgoCD cluster secret has the correct server address:
+
+```bash
+kubectl get secret dev-cluster-secret -n argocd -o jsonpath='{.data.server}' | base64 -d
+```
+
+### Prometheus PVCs stuck in Pending (StorageClass issue)
+
+Delete StatefulSets and PVCs to let ArgoCD recreate with the correct StorageClass:
+
+```bash
+# Connect to the affected cluster (e.g., dev)
+gcloud container clusters get-credentials dev-cluster --region us-central1 --project cluster-dreams
+
+# Delete StatefulSets (PVCs are retained)
+kubectl delete statefulset -n monitoring --all
+
+# Delete PVCs
+kubectl delete pvc -n monitoring --all
+
+# ArgoCD will recreate everything using the values in gke-applications/dev/prometheus.yaml
+# which specifies storageClassName: standard
+```
+
+### Terraform state lock after a failed apply
+
+```bash
+# Get the lock ID from the error message, then:
+terraform workspace select WORKSPACE
+terraform force-unlock LOCK_ID
+```
+
+### Node pool update times out in Terraform
+
+GKE continues the rolling update even if Terraform times out. Options:
+
+1. Wait for GKE to finish, then run `terraform apply` again (it will see nodes are already updated).
+2. Run the update asynchronously:
+
+```bash
+gcloud container node-pools update node-pool-01 \
+  --cluster dev-cluster \
+  --region us-central1 \
+  --project cluster-dreams \
+  --async
+```
+
+3. If Terraform state is corrupt after a timeout, import the node pool:
+
+```bash
+terraform import \
+  'module.gke.google_container_node_pool.pools["node-pool-01"]' \
+  projects/cluster-dreams/locations/us-central1/clusters/dev-cluster/nodePools/node-pool-01
+```
+
+---
+
+## GCP Quota Issues
+
+### Check current quota usage
+
+```bash
+gcloud compute regions describe us-central1 \
+  --project cluster-dreams \
+  --format="table(quotas.metric, quotas.limit, quotas.usage)"
+```
+
+### SSD quota exceeded
+
+Symptoms: PVC stuck in Pending with `Quota 'SSD_TOTAL_GB' exceeded`.
+
+Fix: Ensure Prometheus PVCs use `storageClassName: standard` in `gke-applications/{cluster}/prometheus.yaml`. Then delete the old PVCs (see above).
+
+If node disks are the problem, reduce `disk_size_gb` in `gke.tf` and apply — GKE will roll node pools with smaller disks.
+
+---
+
+## CI/CD Operations
+
+### Submit a test build manually
+
+```bash
+source scripts/gcloud-aliases.sh
+gcb-test
+```
+
+### Stream logs from an active build
+
+```bash
+gcb-logs BUILD_ID
+# or
+gcloud builds log BUILD_ID --stream --region us-central1 --project cluster-dreams
+```
+
+### Trigger the plan pipeline manually
+
+```bash
+gcloud builds triggers run terraform-plan-pr \
+  --region us-central1 \
+  --project cluster-dreams
+```
+
+### Trigger the apply pipeline manually
+
+```bash
+gcloud builds triggers run terraform-apply \
+  --region us-central1 \
+  --project cluster-dreams
+```
+
+---
+
+## Cost Monitoring
+
+### Check which clusters are running
+
+```bash
+gcloud container clusters list \
+  --project cluster-dreams \
+  --region us-central1 \
+  --format="table(name, status, currentNodeCount)"
+```
+
+### Check node count per cluster
+
+```bash
+for cluster in dev-cluster staging-cluster gitops-cluster; do
+  echo "=== $cluster ==="
+  gcloud container clusters describe $cluster \
+    --region us-central1 --project cluster-dreams \
+    --format="value(currentNodeCount)"
+done
+```
+
+### Manually trigger destroy (outside scheduled hours)
+
+```bash
+gcloud builds triggers run terraform-destroy-scheduled \
+  --region us-central1 \
+  --project cluster-dreams
+```
+
+### Manually trigger recreate
+
+```bash
+gcloud builds triggers run terraform-create-scheduled \
+  --region us-central1 \
+  --project cluster-dreams
+```

--- a/gke.tf
+++ b/gke.tf
@@ -27,6 +27,8 @@ module "gke" {
     gpu_resources       = []
     auto_repair         = true
     auto_upgrade        = true
+    disk_size           = 30
+    disk_type           = "pd-standard"
   }
 
   node_pools = [


### PR DESCRIPTION
## Summary

- **Fix NAP disk defaults**: Node Auto-Provisioning was silently defaulting to 100 GB pd-ssd for auto-provisioned nodes. Explicitly set `disk_size=30` and `disk_type=pd-standard` to match the static node pool and avoid SSD quota exhaustion.
- **Add ARCHITECTURE.md**: Hub-spoke cluster design, shared VPC layout, Terraform workspace structure, GitOps/ESO flow, node config, cost optimisation schedule, key file reference.
- **Add ADDING-A-CLUSTER.md**: Step-by-step guide covering subnet allocation, CIDR offsets, workspace creation, ArgoCD/ESO registration, and app directory setup.
- **Add ONBOARDING-AN-APP.md**: ApplicationSet Git generator pattern, YAML format, helm values/valueFiles, real-world examples, naming conventions, update/removal workflow, troubleshooting.
- **Add RUNBOOK.md**: Day-to-day ops — cluster access, Terraform operations, ArgoCD management, ESO secret refresh, failure recovery, quota debugging, CI/CD triggers, cost monitoring.

## Commits

1. `Set NAP disk defaults to 30GB pd-standard` — infrastructure fix
2. `Add architecture documentation`
3. `Add guide for adding a new cluster`
4. `Add guide for onboarding a new application`
5. `Add operational runbook`

## Test plan

- [ ] `terraform plan` on all workspaces shows only the `disk_size`/`disk_type` change under `cluster_autoscaling.auto_provisioning_defaults`
- [ ] Docs render correctly on GitHub