### PR TITLE
Fix Loki datasource URL in Grafana

### DIFF
--- a/gke-applications/dev/prometheus.yaml
+++ b/gke-applications/dev/prometheus.yaml
@@ -24,7 +24,7 @@ helm:
           type: loki
           jsonData:
             tlsSkipVerify: true
-          url: http://loki-stack.logging.svc.cluster.local:3100
+          url: http://loki.logging.svc.cluster.local:3100
           version: 1
     prometheus:
       prometheusSpec:

--- a/gke-applications/gitops/prometheus.yaml
+++ b/gke-applications/gitops/prometheus.yaml
@@ -24,7 +24,7 @@ helm:
           type: loki
           jsonData:
             tlsSkipVerify: true
-          url: http://loki-stack.logging.svc.cluster.local:3100
+          url: http://loki.logging.svc.cluster.local:3100
           version: 1
     prometheus:
       prometheusSpec:

--- a/gke-applications/staging/prometheus.yaml
+++ b/gke-applications/staging/prometheus.yaml
@@ -24,7 +24,7 @@ helm:
           type: loki
           jsonData:
             tlsSkipVerify: true
-          url: http://loki-stack.logging.svc.cluster.local:3100
+          url: http://loki.logging.svc.cluster.local:3100
           version: 1
     prometheus:
       prometheusSpec:


### PR DESCRIPTION
## Summary

- Fix the Loki datasource URL in Grafana (`additionalDataSources`) across all three clusters (dev, staging, gitops).
- The Helm release name is `loki`, so the service is `loki.logging.svc.cluster.local` — not `loki-stack.logging.svc.cluster.local` (the old chart default).
- Without this fix, Grafana's Loki datasource silently fails to connect and log queries return no data.

## Affected files

- `gke-applications/dev/prometheus.yaml`
- `gke-applications/staging/prometheus.yaml`
- `gke-applications/gitops/prometheus.yaml`

## Test plan

- [ ] ArgoCD syncs the updated prometheus-monitoring app on all clusters
- [ ] In Grafana → Connections → Data Sources → Loki → "Test" returns success
- [ ] Log queries in Grafana Explore return data from Loki