### PR TITLE
Parameterize environments and refactor CI/CD pipelines

### DIFF
--- a/argocd.tf
+++ b/argocd.tf
@@ -85,7 +85,7 @@ data "http" "gke_clusters" {
 # Remote clusters - only looked up if they actually exist
 data "google_container_cluster" "remote" {
   for_each = terraform.workspace == "gitops" ? toset([
-    for name in ["dev", "staging"] : name
+    for name in local.remote_workspaces : name
     if can(regex("\"${name}-cluster\"", try(data.http.gke_clusters[0].response_body, "")))
   ]) : toset([])
 

--- a/cicd/cloudbuild-create.yaml
+++ b/cicd/cloudbuild-create.yaml
@@ -1,15 +1,15 @@
 steps:
 # Environment Info
-- name: alpine:latest
+- name: alpine:3.21
   id: environment-info
   entrypoint: /bin/sh
   args:
   - -c
   - |
-    echo "=== Scheduled Recreation - Dev & Staging ==="
+    echo "=== Scheduled Recreation ==="
     echo "Build ID: $BUILD_ID"
     echo "Triggered at: $(date)"
-    echo "Workspaces to create: dev, staging"
+    echo "Workspaces to create: ${_REMOTE_WORKSPACES}"
     echo "============================================"
   timeout: 60s
 
@@ -25,10 +25,12 @@ steps:
   timeout: 300s
 
 ###################
-# DEV WORKSPACE - CREATE
+# CREATE REMOTE WORKSPACES
+# gitops is excluded — it runs continuously and owns the shared network.
+# To add a new environment, add its workspace name to _REMOTE_WORKSPACES below.
 ###################
 
-- id: setup-dev
+- id: create-all
   name: hashicorp/terraform:1.14
   entrypoint: /bin/sh
   waitFor:
@@ -36,210 +38,67 @@ steps:
   args:
   - -c
   - |
-    echo "Setting up workspace: dev"
-
-    setup_workspace() {
-        local workspace_name="dev"
-        local wait_time=5
-        local max_wait_time=120
-
-        echo "Selecting or creating workspace: $workspace_name"
-
-        if ! terraform workspace select $workspace_name 2>/dev/null; then
-            echo "Workspace $workspace_name does not exist, creating..."
-            if ! terraform workspace new $workspace_name; then
-                echo "Failed to create workspace, retrying in ${wait_time}s..."
-                sleep $wait_time
-                terraform workspace new $workspace_name || {
-                    echo "Failed to create workspace after retry"
-                    return 1
-                }
-            fi
-        fi
-
-        echo "Successfully selected workspace: $workspace_name"
-        terraform workspace show
-        return 0
-    }
-
-    setup_workspace
-  timeout: 300s
-
-- id: plan-dev
-  name: hashicorp/terraform:1.14
-  entrypoint: /bin/sh
-  waitFor:
-  - setup-dev
-  args:
-  - -c
-  - |
     set -euo pipefail
-
-    workspace_name="dev"
-    plan_file="/workspace/$BUILD_ID/tfplan_dev"
-
-    echo "Creating plan for workspace: $workspace_name"
     mkdir -p "/workspace/$BUILD_ID"
 
-    terraform workspace select $workspace_name
-    terraform plan -out="$plan_file"
+    for ws in ${_REMOTE_WORKSPACES}; do
+        echo "================================"
+        echo "CREATING workspace: $ws"
+        echo "================================"
 
-    echo "Plan created successfully: $plan_file"
-  timeout: 600s
+        if ! terraform workspace select "$ws" 2>/dev/null; then
+            echo "Workspace $ws does not exist, creating..."
+            terraform workspace new "$ws" || {
+                sleep 5
+                terraform workspace new "$ws"
+            }
+        fi
+        terraform workspace show
 
-- id: apply-dev
-  name: hashicorp/terraform:1.14
-  entrypoint: /bin/sh
-  waitFor:
-  - plan-dev
-  args:
-  - -c
-  - |
-    set -euo pipefail
+        plan_file="/workspace/$BUILD_ID/tfplan_${ws}"
+        terraform plan -out="$plan_file"
 
-    workspace_name="dev"
-    plan_file="/workspace/$BUILD_ID/tfplan_dev"
-
-    echo "================================"
-    echo "Applying workspace: $workspace_name"
-    echo "================================"
-
-    # Backup state before apply
-    if terraform state pull > /tmp/terraform_${workspace_name}_backup_${BUILD_ID}.tfstate 2>/dev/null; then
-        echo "State backup created successfully"
-    fi
-
-    # Apply the plan
-    terraform workspace select $workspace_name
-
-    if terraform apply "$plan_file"; then
-        echo "Successfully applied workspace: $workspace_name"
-        echo "APPLY_STATUS_DEV=SUCCESS" >> $BUILD_ID-status.env
-    else
-        echo "ERROR: Apply failed for workspace: $workspace_name"
-        echo "APPLY_STATUS_DEV=FAILED" >> $BUILD_ID-status.env
-        echo "Backup available at: /tmp/terraform_${workspace_name}_backup_${BUILD_ID}.tfstate"
-        exit 1
-    fi
-  timeout: 1800s
-
-###################
-# STAGING WORKSPACE - CREATE
-###################
-
-- id: setup-staging
-  name: hashicorp/terraform:1.14
-  entrypoint: /bin/sh
-  waitFor:
-  - apply-dev
-  args:
-  - -c
-  - |
-    echo "Setting up workspace: staging"
-
-    setup_workspace() {
-        local workspace_name="staging"
-        local wait_time=5
-        local max_wait_time=120
-
-        echo "Selecting or creating workspace: $workspace_name"
-
-        if ! terraform workspace select $workspace_name 2>/dev/null; then
-            echo "Workspace $workspace_name does not exist, creating..."
-            if ! terraform workspace new $workspace_name; then
-                echo "Failed to create workspace, retrying in ${wait_time}s..."
-                sleep $wait_time
-                terraform workspace new $workspace_name || {
-                    echo "Failed to create workspace after retry"
-                    return 1
-                }
-            fi
+        if terraform state pull > "/tmp/terraform_${ws}_backup_${BUILD_ID}.tfstate" 2>/dev/null; then
+            echo "State backup created for $ws"
         fi
 
-        echo "Successfully selected workspace: $workspace_name"
-        terraform workspace show
-        return 0
-    }
-
-    setup_workspace
-  timeout: 300s
-
-- id: plan-staging
-  name: hashicorp/terraform:1.14
-  entrypoint: /bin/sh
-  waitFor:
-  - setup-staging
-  args:
-  - -c
-  - |
-    set -euo pipefail
-
-    workspace_name="staging"
-    plan_file="/workspace/$BUILD_ID/tfplan_staging"
-
-    echo "Creating plan for workspace: $workspace_name"
-    mkdir -p "/workspace/$BUILD_ID"
-
-    terraform workspace select $workspace_name
-    terraform plan -out="$plan_file"
-
-    echo "Plan created successfully: $plan_file"
-  timeout: 600s
-
-- id: apply-staging
-  name: hashicorp/terraform:1.14
-  entrypoint: /bin/sh
-  waitFor:
-  - plan-staging
-  args:
-  - -c
-  - |
-    set -euo pipefail
-
-    workspace_name="staging"
-    plan_file="/workspace/$BUILD_ID/tfplan_staging"
-
-    echo "================================"
-    echo "Applying workspace: $workspace_name"
-    echo "================================"
-
-    # Backup state before apply
-    if terraform state pull > /tmp/terraform_${workspace_name}_backup_${BUILD_ID}.tfstate 2>/dev/null; then
-        echo "State backup created successfully"
-    fi
-
-    # Apply the plan
-    terraform workspace select $workspace_name
-
-    if terraform apply "$plan_file"; then
-        echo "Successfully applied workspace: $workspace_name"
-        echo "APPLY_STATUS_STAGING=SUCCESS" >> $BUILD_ID-status.env
-    else
-        echo "ERROR: Apply failed for workspace: $workspace_name"
-        echo "APPLY_STATUS_STAGING=FAILED" >> $BUILD_ID-status.env
-        echo "Backup available at: /tmp/terraform_${workspace_name}_backup_${BUILD_ID}.tfstate"
-        exit 1
-    fi
-  timeout: 1800s
+        if terraform apply "$plan_file"; then
+            echo "Successfully applied workspace: $ws"
+            echo "APPLY_STATUS_$(echo $ws | tr '[:lower:]' '[:upper:]')=SUCCESS" >> $BUILD_ID-status.env
+        else
+            echo "ERROR: Apply failed for workspace: $ws"
+            echo "APPLY_STATUS_$(echo $ws | tr '[:lower:]' '[:upper:]')=FAILED" >> $BUILD_ID-status.env
+            exit 1
+        fi
+    done
+  timeout: 3600s
 
 # Summary
-- name: alpine:latest
+- name: alpine:3.21
   id: create-summary
   entrypoint: /bin/sh
+  waitFor:
+  - create-all
   args:
   - -c
   - |
     echo "================================"
     echo "Scheduled Recreation Complete"
-    echo "Recreated workspaces: dev, staging"
+    echo "Recreated workspaces: ${_REMOTE_WORKSPACES}"
     echo "GitOps workspace: Already running"
     echo "Completed at: $(date)"
     echo "Next destroy: 2 AM EST"
     echo "================================"
+    if [ -f "$BUILD_ID-status.env" ]; then cat $BUILD_ID-status.env; fi
   timeout: 60s
 
 options:
   machineType: E2_HIGHCPU_8
   logging: CLOUD_LOGGING_ONLY
+
+substitutions:
+  # Space-separated remote workspaces to recreate (gitops excluded — it runs continuously).
+  # To add a new environment, add its workspace name here.
+  _REMOTE_WORKSPACES: dev staging
 
 timeout: 3600s

--- a/cicd/cloudbuild-create.yaml
+++ b/cicd/cloudbuild-create.yaml
@@ -71,7 +71,7 @@ steps:
             exit 1
         fi
     done
-  timeout: 3600s
+  timeout: 3300s
 
 # Summary
 - name: alpine:3.21

--- a/cicd/cloudbuild-destroy.yaml
+++ b/cicd/cloudbuild-destroy.yaml
@@ -1,15 +1,15 @@
 steps:
 # Environment Info
-- name: alpine:3.18
+- name: alpine:3.21
   id: environment-info
   entrypoint: /bin/sh
   args:
   - -c
   - |
-    echo "=== Scheduled Destroy - Dev & Staging ==="
+    echo "=== Scheduled Destroy ==="
     echo "Build ID: $BUILD_ID"
     echo "Triggered at: $(date)"
-    echo "Workspaces to destroy: dev, staging"
+    echo "Workspaces to destroy: ${_REMOTE_WORKSPACES}"
     echo "========================================"
   timeout: 60s
 
@@ -25,10 +25,12 @@ steps:
   timeout: 300s
 
 ###################
-# DEV WORKSPACE - DESTROY
+# DESTROY REMOTE WORKSPACES
+# gitops is excluded — it owns the shared network and runs continuously.
+# To add a new environment, add its workspace name to _REMOTE_WORKSPACES below.
 ###################
 
-- id: destroy-dev
+- id: destroy-all
   name: hashicorp/terraform:1.14
   entrypoint: /bin/sh
   waitFor:
@@ -38,98 +40,56 @@ steps:
   - |
     set -euo pipefail
 
-    workspace_name="dev"
-    echo "================================"
-    echo "DESTROYING workspace: $workspace_name"
-    echo "Creating state backup before destroy..."
-    echo "================================"
+    for ws in ${_REMOTE_WORKSPACES}; do
+        echo "================================"
+        echo "DESTROYING workspace: $ws"
+        echo "================================"
 
-    # Select workspace
-    terraform workspace select $workspace_name || terraform workspace new $workspace_name
+        terraform workspace select "$ws" || terraform workspace new "$ws"
 
-    # Backup state before destroy
-    if terraform state pull > /tmp/terraform_${workspace_name}_predestroy_${BUILD_ID}.tfstate 2>/dev/null; then
-        echo "State backup created: /tmp/terraform_${workspace_name}_predestroy_${BUILD_ID}.tfstate"
-
-        # Perform destroy
-        echo "Starting destroy operation..."
-        if terraform destroy -auto-approve; then
-            echo "Successfully destroyed workspace: $workspace_name"
-            echo "DESTROY_STATUS=SUCCESS" >> $BUILD_ID-status.env
+        if terraform state pull > "/tmp/terraform_${ws}_predestroy_${BUILD_ID}.tfstate" 2>/dev/null; then
+            echo "State backup created for $ws"
+            if terraform destroy -auto-approve; then
+                echo "Successfully destroyed workspace: $ws"
+                echo "DESTROY_STATUS_$(echo $ws | tr '[:lower:]' '[:upper:]')=SUCCESS" >> $BUILD_ID-status.env
+            else
+                echo "ERROR: Failed to destroy workspace: $ws"
+                echo "DESTROY_STATUS_$(echo $ws | tr '[:lower:]' '[:upper:]')=FAILED" >> $BUILD_ID-status.env
+                exit 1
+            fi
         else
-            echo "ERROR: Failed to destroy workspace: $workspace_name"
-            echo "DESTROY_STATUS=FAILED" >> $BUILD_ID-status.env
-            echo "Backup available at: /tmp/terraform_${workspace_name}_predestroy_${BUILD_ID}.tfstate"
-            exit 1
+            echo "No state found for workspace: $ws, skipping"
+            echo "DESTROY_STATUS_$(echo $ws | tr '[:lower:]' '[:upper:]')=NO_STATE" >> $BUILD_ID-status.env
         fi
-    else
-        echo "No state found for workspace: $workspace_name"
-        echo "DESTROY_STATUS=NO_STATE" >> $BUILD_ID-status.env
-    fi
-  timeout: 1800s
-
-###################
-# STAGING WORKSPACE - DESTROY
-###################
-
-- id: destroy-staging
-  name: hashicorp/terraform:1.14
-  entrypoint: /bin/sh
-  waitFor:
-  - destroy-dev
-  args:
-  - -c
-  - |
-    set -euo pipefail
-
-    workspace_name="staging"
-    echo "================================"
-    echo "DESTROYING workspace: $workspace_name"
-    echo "Creating state backup before destroy..."
-    echo "================================"
-
-    # Select workspace
-    terraform workspace select $workspace_name || terraform workspace new $workspace_name
-
-    # Backup state before destroy
-    if terraform state pull > /tmp/terraform_${workspace_name}_predestroy_${BUILD_ID}.tfstate 2>/dev/null; then
-        echo "State backup created: /tmp/terraform_${workspace_name}_predestroy_${BUILD_ID}.tfstate"
-
-        # Perform destroy
-        echo "Starting destroy operation..."
-        if terraform destroy -auto-approve; then
-            echo "Successfully destroyed workspace: $workspace_name"
-            echo "DESTROY_STATUS=SUCCESS" >> $BUILD_ID-status.env
-        else
-            echo "ERROR: Failed to destroy workspace: $workspace_name"
-            echo "DESTROY_STATUS=FAILED" >> $BUILD_ID-status.env
-            echo "Backup available at: /tmp/terraform_${workspace_name}_predestroy_${BUILD_ID}.tfstate"
-            exit 1
-        fi
-    else
-        echo "No state found for workspace: $workspace_name"
-        echo "DESTROY_STATUS=NO_STATE" >> $BUILD_ID-status.env
-    fi
-  timeout: 1800s
+    done
+  timeout: 3600s
 
 # Summary
-- name: alpine:3.18
+- name: alpine:3.21
   id: destroy-summary
   entrypoint: /bin/sh
+  waitFor:
+  - destroy-all
   args:
   - -c
   - |
     echo "================================"
     echo "Scheduled Destroy Complete"
-    echo "Destroyed workspaces: dev, staging"
+    echo "Destroyed workspaces: ${_REMOTE_WORKSPACES}"
     echo "GitOps workspace: PRESERVED (has shared network)"
     echo "Completed at: $(date)"
     echo "Next recreation: 10 AM EST"
     echo "================================"
+    if [ -f "$BUILD_ID-status.env" ]; then cat $BUILD_ID-status.env; fi
   timeout: 60s
 
 options:
   machineType: E2_HIGHCPU_8
   logging: CLOUD_LOGGING_ONLY
+
+substitutions:
+  # Space-separated remote workspaces to destroy (gitops excluded — it owns the shared network).
+  # To add a new environment, add its workspace name here.
+  _REMOTE_WORKSPACES: dev staging
 
 timeout: 3600s

--- a/cicd/cloudbuild-destroy.yaml
+++ b/cicd/cloudbuild-destroy.yaml
@@ -62,7 +62,7 @@ steps:
             echo "DESTROY_STATUS_$(echo $ws | tr '[:lower:]' '[:upper:]')=NO_STATE" >> $BUILD_ID-status.env
         fi
     done
-  timeout: 3600s
+  timeout: 3300s
 
 # Summary
 - name: alpine:3.21

--- a/cicd/cloudbuild-plan.yaml
+++ b/cicd/cloudbuild-plan.yaml
@@ -19,6 +19,8 @@ steps:
 - id: terraform-init
   name: hashicorp/terraform:1.14
   entrypoint: /bin/sh
+  secretEnv:
+  - GOOGLE_CREDENTIALS
   args:
   - -c
   - |
@@ -38,6 +40,8 @@ steps:
   entrypoint: /bin/sh
   waitFor:
   - terraform-init
+  secretEnv:
+  - GOOGLE_CREDENTIALS
   args:
   - -c
   - |
@@ -130,6 +134,11 @@ steps:
     echo "Review the detailed plans above"
     echo "================================"
   timeout: 60s
+
+availableSecrets:
+  secretManager:
+  - versionName: projects/$PROJECT_ID/secrets/terraform-service-account/versions/latest
+    env: GOOGLE_CREDENTIALS
 
 options:
   machineType: E2_HIGHCPU_8

--- a/cicd/cloudbuild-plan.yaml
+++ b/cicd/cloudbuild-plan.yaml
@@ -1,6 +1,6 @@
 steps:
 # Environment Info
-- name: alpine:3.18
+- name: alpine:3.21
   id: environment-info
   entrypoint: /bin/sh
   args:
@@ -9,8 +9,9 @@ steps:
     echo "=== PR Terraform Plan ==="
     echo "Build ID: $BUILD_ID"
     echo "Branch: $BRANCH_NAME"
-    echo "PR Number: $(_PR_NUMBER)"
+    echo "PR Number: ${_PR_NUMBER}"
     echo "Commit SHA: $SHORT_SHA"
+    echo "Workspaces: ${_WORKSPACES}"
     echo "========================="
   timeout: 60s
 
@@ -27,10 +28,12 @@ steps:
   timeout: 300s
 
 ###################
-# GITOPS WORKSPACE - PLAN
+# PLAN ALL WORKSPACES
+# gitops first (owns shared network), then remaining workspaces in order.
+# To add a new environment, update _WORKSPACES in the substitutions section below.
 ###################
 
-- id: setup-gitops-plan
+- id: plan-all
   name: hashicorp/terraform:1.14
   entrypoint: /bin/sh
   waitFor:
@@ -38,208 +41,53 @@ steps:
   args:
   - -c
   - |
-    workspace_name="gitops"
-    echo "Selecting workspace: $workspace_name"
-    terraform workspace select $workspace_name || terraform workspace new $workspace_name
-    terraform workspace show
-  timeout: 300s
-
-- id: plan-gitops
-  name: hashicorp/terraform:1.14
-  entrypoint: /bin/sh
-  waitFor:
-  - setup-gitops-plan
-  args:
-  - -c
-  - |
     set -euo pipefail
-    workspace_name="gitops"
-    plan_output="/workspace/plan_${workspace_name}.txt"
 
-    echo "================================"
-    echo "PLANNING workspace: $workspace_name"
-    echo "================================"
+    for ws in ${_WORKSPACES}; do
+        echo "================================"
+        echo "PLANNING workspace: $ws"
+        echo "================================"
+        terraform workspace select "$ws" || terraform workspace new "$ws"
 
-    terraform workspace select $workspace_name
+        plan_output="/workspace/plan_${ws}.txt"
 
-    # Run plan and capture output
-    if terraform plan -no-color -out=/workspace/tfplan_${workspace_name} | tee "$plan_output"; then
-        echo ""
-        echo "✓ Plan successful for workspace: $workspace_name"
-
-        # Check if there are changes
-        if grep -q "No changes" "$plan_output"; then
-            echo "STATUS: No changes detected"
+        if terraform plan -no-color -out="/workspace/tfplan_${ws}" | tee "$plan_output"; then
+            echo "✓ Plan successful for workspace: $ws"
+            if grep -q "No changes" "$plan_output"; then
+                echo "STATUS: No changes detected"
+            else
+                echo "STATUS: Changes detected"
+                terraform show -json "/workspace/tfplan_${ws}" > "/workspace/tfplan_${ws}.json"
+            fi
         else
-            echo "STATUS: Changes detected"
-            terraform show -json /workspace/tfplan_${workspace_name} > /workspace/tfplan_${workspace_name}.json
+            echo "✗ Plan failed for workspace: $ws"
+            exit 1
         fi
-    else
-        echo "✗ Plan failed for workspace: $workspace_name"
-        exit 1
-    fi
-  timeout: 600s
+    done
+  timeout: 3600s
 
-- id: summarize-gitops-plan
+###################
+# SUMMARIZE ALL WORKSPACES
+###################
+
+- id: summarize-all
   name: ghcr.io/dineshba/tf-summarize:latest
   waitFor:
-  - plan-gitops
+  - plan-all
   entrypoint: /bin/sh
   args:
   - -c
   - |
-    json_file="/workspace/tfplan_gitops.json"
-    if [ -f "$json_file" ]; then
-        echo "=== Plan Summary: gitops ==="
-        tf-summarize "$json_file"
-        echo "============================"
-    else
-        echo "No changes detected for gitops"
-    fi
-  timeout: 120s
-
-###################
-# DEV WORKSPACE - PLAN
-###################
-
-- id: setup-dev-plan
-  name: hashicorp/terraform:1.14
-  entrypoint: /bin/sh
-  waitFor:
-  - plan-gitops
-  args:
-  - -c
-  - |
-    workspace_name="dev"
-    echo "Selecting workspace: $workspace_name"
-    terraform workspace select $workspace_name || terraform workspace new $workspace_name
-    terraform workspace show
-  timeout: 300s
-
-- id: plan-dev
-  name: hashicorp/terraform:1.14
-  entrypoint: /bin/sh
-  waitFor:
-  - setup-dev-plan
-  args:
-  - -c
-  - |
-    set -euo pipefail
-    workspace_name="dev"
-    plan_output="/workspace/plan_${workspace_name}.txt"
-
-    echo "================================"
-    echo "PLANNING workspace: $workspace_name"
-    echo "================================"
-
-    terraform workspace select $workspace_name
-
-    # Run plan and capture output
-    if terraform plan -no-color -out=/workspace/tfplan_${workspace_name} | tee "$plan_output"; then
-        echo ""
-        echo "✓ Plan successful for workspace: $workspace_name"
-
-        # Check if there are changes
-        if grep -q "No changes" "$plan_output"; then
-            echo "STATUS: No changes detected"
+    for ws in ${_WORKSPACES}; do
+        json_file="/workspace/tfplan_${ws}.json"
+        if [ -f "$json_file" ]; then
+            echo "=== Plan Summary: $ws ==="
+            tf-summarize "$json_file"
+            echo "=========================="
         else
-            echo "STATUS: Changes detected"
-            terraform show -json /workspace/tfplan_${workspace_name} > /workspace/tfplan_${workspace_name}.json
+            echo "No changes detected for $ws"
         fi
-    else
-        echo "✗ Plan failed for workspace: $workspace_name"
-        exit 1
-    fi
-  timeout: 600s
-
-- id: summarize-dev-plan
-  name: ghcr.io/dineshba/tf-summarize:latest
-  waitFor:
-  - plan-dev
-  entrypoint: /bin/sh
-  args:
-  - -c
-  - |
-    json_file="/workspace/tfplan_dev.json"
-    if [ -f "$json_file" ]; then
-        echo "=== Plan Summary: dev ==="
-        tf-summarize "$json_file"
-        echo "========================="
-    else
-        echo "No changes detected for dev"
-    fi
-  timeout: 120s
-
-###################
-# STAGING WORKSPACE - PLAN
-###################
-
-- id: setup-staging-plan
-  name: hashicorp/terraform:1.14
-  entrypoint: /bin/sh
-  waitFor:
-  - plan-dev
-  args:
-  - -c
-  - |
-    workspace_name="staging"
-    echo "Selecting workspace: $workspace_name"
-    terraform workspace select $workspace_name || terraform workspace new $workspace_name
-    terraform workspace show
-  timeout: 300s
-
-- id: plan-staging
-  name: hashicorp/terraform:1.14
-  entrypoint: /bin/sh
-  waitFor:
-  - setup-staging-plan
-  args:
-  - -c
-  - |
-    set -euo pipefail
-    workspace_name="staging"
-    plan_output="/workspace/plan_${workspace_name}.txt"
-
-    echo "================================"
-    echo "PLANNING workspace: $workspace_name"
-    echo "================================"
-
-    terraform workspace select $workspace_name
-
-    # Run plan and capture output
-    if terraform plan -no-color -out=/workspace/tfplan_${workspace_name} | tee "$plan_output"; then
-        echo ""
-        echo "✓ Plan successful for workspace: $workspace_name"
-
-        # Check if there are changes
-        if grep -q "No changes" "$plan_output"; then
-            echo "STATUS: No changes detected"
-        else
-            echo "STATUS: Changes detected"
-            terraform show -json /workspace/tfplan_${workspace_name} > /workspace/tfplan_${workspace_name}.json
-        fi
-    else
-        echo "✗ Plan failed for workspace: $workspace_name"
-        exit 1
-    fi
-  timeout: 600s
-
-- id: summarize-staging-plan
-  name: ghcr.io/dineshba/tf-summarize:latest
-  waitFor:
-  - plan-staging
-  entrypoint: /bin/sh
-  args:
-  - -c
-  - |
-    json_file="/workspace/tfplan_staging.json"
-    if [ -f "$json_file" ]; then
-        echo "=== Plan Summary: staging ==="
-        tf-summarize "$json_file"
-        echo "============================="
-    else
-        echo "No changes detected for staging"
-    fi
+    done
   timeout: 120s
 
 ###################
@@ -247,12 +95,10 @@ steps:
 ###################
 
 - id: generate-summary
-  name: alpine:3.18
+  name: alpine:3.21
   entrypoint: /bin/sh
   waitFor:
-  - summarize-gitops-plan
-  - summarize-dev-plan
-  - summarize-staging-plan
+  - summarize-all
   args:
   - -c
   - |
@@ -260,14 +106,13 @@ steps:
     echo "Plan Summary"
     echo "================================"
 
-    for workspace in gitops dev staging; do
-        plan_file="/workspace/plan_${workspace}.txt"
+    for ws in ${_WORKSPACES}; do
+        plan_file="/workspace/plan_${ws}.txt"
 
         echo ""
-        echo "--- Workspace: $workspace ---"
+        echo "--- Workspace: $ws ---"
 
         if [ -f "$plan_file" ]; then
-            # Extract summary line
             if grep -q "No changes" "$plan_file"; then
                 echo "✓ No changes"
             elif grep -q "Plan:" "$plan_file"; then
@@ -292,5 +137,9 @@ options:
 
 substitutions:
   _PR_NUMBER: ""
+  # Space-separated list of workspaces to plan, in order.
+  # gitops must be first (it owns the shared network).
+  # To add a new environment, add its workspace name here.
+  _WORKSPACES: gitops dev staging
 
 timeout: 2400s

--- a/cicd/cloudbuild-plan.yaml
+++ b/cicd/cloudbuild-plan.yaml
@@ -64,7 +64,7 @@ steps:
             exit 1
         fi
     done
-  timeout: 3600s
+  timeout: 2000s
 
 ###################
 # SUMMARIZE ALL WORKSPACES
@@ -142,4 +142,4 @@ substitutions:
   # To add a new environment, add its workspace name here.
   _WORKSPACES: gitops dev staging
 
-timeout: 2400s
+timeout: 3600s

--- a/cicd/cloudbuild-test.yaml
+++ b/cicd/cloudbuild-test.yaml
@@ -1,6 +1,6 @@
 steps:
 # Environment info step - test basic functionality
-- name: alpine:3.18
+- name: alpine:3.21
   id: environment-info
   entrypoint: /bin/sh
   args:
@@ -92,7 +92,7 @@ steps:
   timeout: 300s
 
 # Summary step
-- name: alpine:3.18
+- name: alpine:3.21
   id: test-summary
   entrypoint: /bin/sh
   args:

--- a/cicd/cloudbuild.yaml
+++ b/cicd/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 # Environment Info
-- name: alpine:3.18
+- name: alpine:3.21
   id: environment-info
   entrypoint: /bin/sh
   args:
@@ -12,6 +12,7 @@ steps:
     echo "Pull Request: ${_PR_NUMBER:-N/A}"
     echo "Project ID: $PROJECT_ID"
     echo "Commit SHA: ${COMMIT_SHA:-N/A}"
+    echo "Workspaces: ${_WORKSPACES}"
     echo "=================================="
     echo "BUILD_START=$(date -Iseconds)" > $BUILD_ID-status.env
   timeout: 60s
@@ -103,10 +104,12 @@ steps:
   timeout: 120s
 
 ###################
-# GITOPS WORKSPACE
+# PLAN ALL WORKSPACES
+# Runs gitops first (owns shared network), then remaining workspaces in order.
+# To add a new workspace, update _WORKSPACES in the substitutions section below.
 ###################
 
-- id: setup-gitops
+- id: plan-all
   name: hashicorp/terraform:1.14
   waitFor:
   - security-report
@@ -120,78 +123,76 @@ steps:
         set -euo pipefail
         echo "Initializing Terraform..."
         terraform init -reconfigure -upgrade -input=false
-        terraform workspace select gitops || terraform workspace new gitops
-        echo "Running Terraform validation..."
         terraform validate
-    else
-        echo "Skipping setup on branch $BRANCH_NAME"
-        exit 0
-    fi
-  timeout: 600s
 
-- id: plan-gitops
-  name: hashicorp/terraform:1.14
-  waitFor:
-  - setup-gitops
-  entrypoint: /bin/sh
-  secretEnv:
-  - GOOGLE_CREDENTIALS
-  args:
-  - -c
-  - |
-    if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "master" ] || [ -n "${_PR_NUMBER:-}" ]; then
-        set -euo pipefail
-        terraform workspace select gitops
-        plan_file="/workspace/$BUILD_ID/tfplan_gitops"
-        plan_output="/tmp/plan_output_gitops.txt"
-        mkdir -p "$(dirname "$plan_file")"
+        mkdir -p "/workspace/$BUILD_ID"
 
-        set +eo pipefail
-        terraform plan \
-            -detailed-exitcode \
-            -parallelism=30 \
-            -var="project_id=$PROJECT_ID" \
-            -out="$plan_file" \
-            > "$plan_output" 2>&1; plan_exit_code=$?
-        cat "$plan_output"
-        set -e
+        for ws in ${_WORKSPACES}; do
+            echo "================================"
+            echo "PLANNING workspace: $ws"
+            echo "================================"
+            terraform workspace select "$ws" || terraform workspace new "$ws"
 
-        case $plan_exit_code in
-            0) echo "No changes detected" ;;
-            1) echo "Plan failed"; exit 1 ;;
-            2)
-                echo "Plan succeeded with changes"
-                terraform show -json "$plan_file" > "${plan_file}.json"
-                ;;
-        esac
-        exit 0
+            plan_file="/workspace/$BUILD_ID/tfplan_${ws}"
+            plan_output="/tmp/plan_output_${ws}.txt"
+
+            set +eo pipefail
+            terraform plan \
+                -detailed-exitcode \
+                -parallelism=30 \
+                -var="project_id=$PROJECT_ID" \
+                -out="$plan_file" \
+                > "$plan_output" 2>&1; plan_exit_code=$?
+            cat "$plan_output"
+            set -e
+
+            case $plan_exit_code in
+                0) echo "No changes detected for $ws" ;;
+                1) echo "Plan failed for $ws"; exit 1 ;;
+                2)
+                    echo "Plan succeeded with changes for $ws"
+                    terraform show -json "$plan_file" > "${plan_file}.json"
+                    ;;
+            esac
+        done
     else
         echo "Skipping plan on branch $BRANCH_NAME"
     fi
-  timeout: 1200s
+  timeout: 3600s
 
-- id: summarize-gitops
+###################
+# SUMMARIZE ALL WORKSPACES
+###################
+
+- id: summarize-all
   name: ghcr.io/dineshba/tf-summarize:latest
   waitFor:
-  - plan-gitops
+  - plan-all
   entrypoint: /bin/sh
   args:
   - -c
   - |
-    json_file="/workspace/$BUILD_ID/tfplan_gitops.json"
-    if [ -f "$json_file" ]; then
-        echo "=== Plan Summary: gitops ==="
-        tf-summarize "$json_file"
-        echo "============================"
-    else
-        echo "No changes detected for gitops"
-    fi
+    for ws in ${_WORKSPACES}; do
+        json_file="/workspace/$BUILD_ID/tfplan_${ws}.json"
+        if [ -f "$json_file" ]; then
+            echo "=== Plan Summary: $ws ==="
+            tf-summarize "$json_file"
+            echo "=========================="
+        else
+            echo "No changes detected for $ws"
+        fi
+    done
   timeout: 120s
 
-- id: apply-gitops
+###################
+# APPLY ALL WORKSPACES
+# gitops first (shared network), then remaining workspaces in order.
+###################
+
+- id: apply-all
   name: hashicorp/terraform:1.14
   waitFor:
-  - summarize-gitops
+  - summarize-all
   entrypoint: /bin/sh
   secretEnv:
   - GOOGLE_CREDENTIALS
@@ -201,295 +202,47 @@ steps:
     if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "master" ]; then
         set -euo pipefail
         terraform init -reconfigure -upgrade -input=false
-        terraform workspace select gitops
-        plan_file="/workspace/$BUILD_ID/tfplan_gitops"
 
-        if [ ! -f "$plan_file" ]; then
-            echo "Error: Plan file not found: $plan_file"
-            exit 1
-        fi
+        for ws in ${_WORKSPACES}; do
+            echo "================================"
+            echo "APPLYING workspace: $ws"
+            echo "================================"
+            terraform workspace select "$ws"
 
-        echo "Creating state backup..."
-        terraform state pull > "/tmp/terraform_gitops_backup_${BUILD_ID}.tfstate"
+            plan_file="/workspace/$BUILD_ID/tfplan_${ws}"
+            if [ ! -f "$plan_file" ]; then
+                echo "No plan file for $ws (no changes), skipping apply"
+                continue
+            fi
 
-        echo "Starting Terraform apply..."
-        start_time=$(date +%s)
-        if terraform apply -parallelism=30 -auto-approve -input=false "$plan_file"; then
-            end_time=$(date +%s)
-            duration=$((end_time - start_time))
-            echo "Apply completed successfully in $duration seconds"
-            echo "APPLY_STATUS_GITOPS=SUCCESS" >> $BUILD_ID-status.env
-        else
-            echo "Apply failed for workspace: gitops"
-            echo "APPLY_STATUS_GITOPS=FAILED" >> $BUILD_ID-status.env
-            exit 1
-        fi
+            echo "Creating state backup..."
+            terraform state pull > "/tmp/terraform_${ws}_backup_${BUILD_ID}.tfstate"
+
+            start_time=$(date +%s)
+            if terraform apply -parallelism=30 -auto-approve -input=false "$plan_file"; then
+                end_time=$(date +%s)
+                echo "Apply completed for $ws in $((end_time - start_time))s"
+                echo "APPLY_STATUS_$(echo $ws | tr '[:lower:]' '[:upper:]')=SUCCESS" >> $BUILD_ID-status.env
+            else
+                echo "Apply failed for workspace: $ws"
+                echo "APPLY_STATUS_$(echo $ws | tr '[:lower:]' '[:upper:]')=FAILED" >> $BUILD_ID-status.env
+                exit 1
+            fi
+        done
     else
         echo "Skipping apply on branch $BRANCH_NAME (only runs on main/master)"
     fi
-  timeout: 2400s
-
-###################
-# DEV WORKSPACE
-###################
-
-- id: setup-dev
-  name: hashicorp/terraform:1.14
-  waitFor:
-  - apply-gitops
-  entrypoint: /bin/sh
-  secretEnv:
-  - GOOGLE_CREDENTIALS
-  args:
-  - -c
-  - |
-    if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "master" ] || [ -n "${_PR_NUMBER:-}" ]; then
-        set -euo pipefail
-        terraform init -reconfigure -upgrade -input=false
-        terraform workspace select dev || terraform workspace new dev
-        terraform validate
-    else
-        echo "Skipping setup on branch $BRANCH_NAME"
-        exit 0
-    fi
-  timeout: 600s
-
-- id: plan-dev
-  name: hashicorp/terraform:1.14
-  waitFor:
-  - setup-dev
-  entrypoint: /bin/sh
-  secretEnv:
-  - GOOGLE_CREDENTIALS
-  args:
-  - -c
-  - |
-    if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "master" ] || [ -n "${_PR_NUMBER:-}" ]; then
-        set -euo pipefail
-        terraform workspace select dev
-        plan_file="/workspace/$BUILD_ID/tfplan_dev"
-        plan_output="/tmp/plan_output_dev.txt"
-        mkdir -p "$(dirname "$plan_file")"
-
-        set +eo pipefail
-        terraform plan \
-            -detailed-exitcode \
-            -parallelism=30 \
-            -var="project_id=$PROJECT_ID" \
-            -out="$plan_file" \
-            > "$plan_output" 2>&1; plan_exit_code=$?
-        cat "$plan_output"
-        set -e
-
-        case $plan_exit_code in
-            0) echo "No changes detected" ;;
-            1) echo "Plan failed"; exit 1 ;;
-            2)
-                echo "Plan succeeded with changes"
-                terraform show -json "$plan_file" > "${plan_file}.json"
-                ;;
-        esac
-        exit 0
-    else
-        echo "Skipping plan on branch $BRANCH_NAME"
-    fi
-  timeout: 1200s
-
-- id: summarize-dev
-  name: ghcr.io/dineshba/tf-summarize:latest
-  waitFor:
-  - plan-dev
-  entrypoint: /bin/sh
-  args:
-  - -c
-  - |
-    json_file="/workspace/$BUILD_ID/tfplan_dev.json"
-    if [ -f "$json_file" ]; then
-        echo "=== Plan Summary: dev ==="
-        tf-summarize "$json_file"
-        echo "========================="
-    else
-        echo "No changes detected for dev"
-    fi
-  timeout: 120s
-
-- id: apply-dev
-  name: hashicorp/terraform:1.14
-  waitFor:
-  - summarize-dev
-  entrypoint: /bin/sh
-  secretEnv:
-  - GOOGLE_CREDENTIALS
-  args:
-  - -c
-  - |
-    if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "master" ]; then
-        set -euo pipefail
-        terraform init -reconfigure -upgrade -input=false
-        terraform workspace select dev
-        plan_file="/workspace/$BUILD_ID/tfplan_dev"
-
-        if [ ! -f "$plan_file" ]; then
-            echo "Error: Plan file not found: $plan_file"
-            exit 1
-        fi
-
-        echo "Creating state backup..."
-        terraform state pull > "/tmp/terraform_dev_backup_${BUILD_ID}.tfstate"
-
-        echo "Starting Terraform apply..."
-        start_time=$(date +%s)
-        if terraform apply -parallelism=30 -auto-approve -input=false "$plan_file"; then
-            end_time=$(date +%s)
-            duration=$((end_time - start_time))
-            echo "Apply completed successfully in $duration seconds"
-            echo "APPLY_STATUS_DEV=SUCCESS" >> $BUILD_ID-status.env
-        else
-            echo "Apply failed for workspace: dev"
-            echo "APPLY_STATUS_DEV=FAILED" >> $BUILD_ID-status.env
-            exit 1
-        fi
-    else
-        echo "Skipping apply on branch $BRANCH_NAME (only runs on main/master)"
-    fi
-  timeout: 2400s
-
-###################
-# STAGING WORKSPACE
-###################
-
-- id: setup-staging
-  name: hashicorp/terraform:1.14
-  waitFor:
-  - apply-dev
-  entrypoint: /bin/sh
-  secretEnv:
-  - GOOGLE_CREDENTIALS
-  args:
-  - -c
-  - |
-    if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "master" ] || [ -n "${_PR_NUMBER:-}" ]; then
-        set -euo pipefail
-        terraform init -reconfigure -upgrade -input=false
-        terraform workspace select staging || terraform workspace new staging
-        terraform validate
-    else
-        echo "Skipping setup on branch $BRANCH_NAME"
-        exit 0
-    fi
-  timeout: 600s
-
-- id: plan-staging
-  name: hashicorp/terraform:1.14
-  waitFor:
-  - setup-staging
-  entrypoint: /bin/sh
-  secretEnv:
-  - GOOGLE_CREDENTIALS
-  args:
-  - -c
-  - |
-    if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "master" ] || [ -n "${_PR_NUMBER:-}" ]; then
-        set -euo pipefail
-        terraform workspace select staging
-        plan_file="/workspace/$BUILD_ID/tfplan_staging"
-        plan_output="/tmp/plan_output_staging.txt"
-        mkdir -p "$(dirname "$plan_file")"
-
-        set +eo pipefail
-        terraform plan \
-            -detailed-exitcode \
-            -parallelism=30 \
-            -var="project_id=$PROJECT_ID" \
-            -out="$plan_file" \
-            > "$plan_output" 2>&1; plan_exit_code=$?
-        cat "$plan_output"
-        set -e
-
-        case $plan_exit_code in
-            0) echo "No changes detected" ;;
-            1) echo "Plan failed"; exit 1 ;;
-            2)
-                echo "Plan succeeded with changes"
-                terraform show -json "$plan_file" > "${plan_file}.json"
-                ;;
-        esac
-        exit 0
-    else
-        echo "Skipping plan on branch $BRANCH_NAME"
-    fi
-  timeout: 1200s
-
-- id: summarize-staging
-  name: ghcr.io/dineshba/tf-summarize:latest
-  waitFor:
-  - plan-staging
-  entrypoint: /bin/sh
-  args:
-  - -c
-  - |
-    json_file="/workspace/$BUILD_ID/tfplan_staging.json"
-    if [ -f "$json_file" ]; then
-        echo "=== Plan Summary: staging ==="
-        tf-summarize "$json_file"
-        echo "============================="
-    else
-        echo "No changes detected for staging"
-    fi
-  timeout: 120s
-
-- id: apply-staging
-  name: hashicorp/terraform:1.14
-  waitFor:
-  - summarize-staging
-  entrypoint: /bin/sh
-  secretEnv:
-  - GOOGLE_CREDENTIALS
-  args:
-  - -c
-  - |
-    if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "master" ]; then
-        set -euo pipefail
-        terraform init -reconfigure -upgrade -input=false
-        terraform workspace select staging
-        plan_file="/workspace/$BUILD_ID/tfplan_staging"
-
-        if [ ! -f "$plan_file" ]; then
-            echo "Error: Plan file not found: $plan_file"
-            exit 1
-        fi
-
-        echo "Creating state backup..."
-        terraform state pull > "/tmp/terraform_staging_backup_${BUILD_ID}.tfstate"
-
-        echo "Starting Terraform apply..."
-        start_time=$(date +%s)
-        if terraform apply -parallelism=30 -auto-approve -input=false "$plan_file"; then
-            end_time=$(date +%s)
-            duration=$((end_time - start_time))
-            echo "Apply completed successfully in $duration seconds"
-            echo "APPLY_STATUS_STAGING=SUCCESS" >> $BUILD_ID-status.env
-        else
-            echo "Apply failed for workspace: staging"
-            echo "APPLY_STATUS_STAGING=FAILED" >> $BUILD_ID-status.env
-            exit 1
-        fi
-    else
-        echo "Skipping apply on branch $BRANCH_NAME (only runs on main/master)"
-    fi
-  timeout: 2400s
+  timeout: 7200s
 
 ###################
 # BUILD SUMMARY
 ###################
 
-- name: alpine:3.18
+- name: alpine:3.21
   id: build-summary
   entrypoint: /bin/sh
   waitFor:
-  - apply-gitops
-  - apply-dev
-  - apply-staging
+  - apply-all
   args:
   - -c
   - |
@@ -503,7 +256,7 @@ steps:
     touch $BUILD_ID-plan-summary.txt
   timeout: 60s
 
-timeout: 3600s
+timeout: 7200s
 options:
   substitutionOption: ALLOW_LOOSE
   logging: CLOUD_LOGGING_ONLY
@@ -512,6 +265,10 @@ options:
 substitutions:
   _PR_NUMBER: ''
   _TERRAFORM_VERSION: '1.14'
+  # Space-separated list of workspaces to plan/apply, in order.
+  # gitops must be first (it owns the shared network).
+  # To add a new environment, add its workspace name here.
+  _WORKSPACES: gitops dev staging
 availableSecrets:
   secretManager:
   - versionName: projects/$PROJECT_ID/secrets/terraform-service-account/versions/latest

--- a/cicd/cloudbuild.yaml
+++ b/cicd/cloudbuild.yaml
@@ -232,7 +232,7 @@ steps:
     else
         echo "Skipping apply on branch $BRANCH_NAME (only runs on main/master)"
     fi
-  timeout: 7200s
+  timeout: 6900s
 
 ###################
 # BUILD SUMMARY

--- a/eso.tf
+++ b/eso.tf
@@ -145,7 +145,17 @@ resource "kubectl_manifest" "argocd_external_secret" {
           data = {
             name   = "{{ .name }}"
             server = "https://{{ .endpoint }}"
-            config = "{\"execProviderConfig\":{\"command\":\"argocd-k8s-auth\",\"args\":[\"gcp\"],\"apiVersion\":\"client.authentication.k8s.io/v1beta1\"},\"tlsClientConfig\":{\"insecure\":false,\"caData\":\"{{ .ca_cert }}\"}}"
+            config = jsonencode({
+              execProviderConfig = {
+                command    = "argocd-k8s-auth"
+                args       = ["gcp"]
+                apiVersion = "client.authentication.k8s.io/v1beta1"
+              }
+              tlsClientConfig = {
+                insecure = false
+                caData   = "{{ .ca_cert }}"
+              }
+            })
           }
         }
       }

--- a/locals.tf
+++ b/locals.tf
@@ -1,11 +1,32 @@
 locals {
-  cluster_types = toset(["gitops", "dev", "staging"])
-  # Master CIDR offsets for different environments
-  master_cidr_offsets = {
-    dev     = "0"
-    staging = "1"
-    gitops  = "2"
+  # Single source of truth for all environments.
+  # To add a new environment (e.g. "prod"):
+  #   1. Add an entry here with a unique node_cidr, range_base, and master_cidr_offset
+  #   2. Create gke-applications/prod/ with app definitions
+  #   3. Run: terraform workspace new prod && terraform apply
+  environments = {
+    dev = {
+      node_cidr          = "10.10.0.0/17"
+      range_base         = "172.16.0.0/17"
+      master_cidr_offset = 0
+    }
+    staging = {
+      node_cidr          = "10.20.0.0/17"
+      range_base         = "172.17.0.0/17"
+      master_cidr_offset = 1
+    }
+    gitops = {
+      node_cidr          = "10.30.0.0/17"
+      range_base         = "172.18.0.0/17"
+      master_cidr_offset = 2
+    }
   }
+
+  # All non-gitops workspaces — used to discover remote clusters for ArgoCD
+  remote_workspaces = [for env in keys(local.environments) : env if env != "gitops"]
+
+  # Derived lookups (keep backwards-compatible names used elsewhere)
+  master_cidr_offsets = { for env, cfg in local.environments : env => tostring(cfg.master_cidr_offset) }
   # Shared network name - gitops creates, others reference via data source
   shared_network_name = terraform.workspace == "gitops" ? module.shared-network[0].network_name : data.google_compute_network.shared_network[0].name
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,14 +1,9 @@
 locals {
-  # Stable alphabetical ordering used to derive per-environment indexes
-  sorted_envs = sort(keys(var.environments))
-  env_index   = { for env in local.sorted_envs : env => index(local.sorted_envs, env) }
-
   # All non-gitops workspaces — used to discover remote clusters for ArgoCD
-  remote_workspaces = [for env in local.sorted_envs : env if env != "gitops"]
+  remote_workspaces = [for env in keys(var.environments) : env if env != "gitops"]
 
-  # Derived lookups (keep backwards-compatible names used elsewhere)
-  # range_base: cidrsubnet("172.16.0.0/12", 5, i) gives 172.16.0.0/17, 172.17.0.0/17, 172.18.0.0/17 ...
-  master_cidr_offsets = { for env in local.sorted_envs : env => tostring(local.env_index[env]) }
+  # Derived lookups
+  master_cidr_offsets = { for env, cfg in var.environments : env => tostring(cfg.master_cidr_offset) }
   # Shared network name - gitops creates, others reference via data source
   shared_network_name = terraform.workspace == "gitops" ? module.shared-network[0].network_name : data.google_compute_network.shared_network[0].name
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,32 +1,14 @@
 locals {
-  # Single source of truth for all environments.
-  # To add a new environment (e.g. "prod"):
-  #   1. Add an entry here with a unique node_cidr, range_base, and master_cidr_offset
-  #   2. Create gke-applications/prod/ with app definitions
-  #   3. Run: terraform workspace new prod && terraform apply
-  environments = {
-    dev = {
-      node_cidr          = "10.10.0.0/17"
-      range_base         = "172.16.0.0/17"
-      master_cidr_offset = 0
-    }
-    staging = {
-      node_cidr          = "10.20.0.0/17"
-      range_base         = "172.17.0.0/17"
-      master_cidr_offset = 1
-    }
-    gitops = {
-      node_cidr          = "10.30.0.0/17"
-      range_base         = "172.18.0.0/17"
-      master_cidr_offset = 2
-    }
-  }
+  # Stable alphabetical ordering used to derive per-environment indexes
+  sorted_envs = sort(keys(var.environments))
+  env_index   = { for env in local.sorted_envs : env => index(local.sorted_envs, env) }
 
   # All non-gitops workspaces — used to discover remote clusters for ArgoCD
-  remote_workspaces = [for env in keys(local.environments) : env if env != "gitops"]
+  remote_workspaces = [for env in local.sorted_envs : env if env != "gitops"]
 
   # Derived lookups (keep backwards-compatible names used elsewhere)
-  master_cidr_offsets = { for env, cfg in local.environments : env => tostring(cfg.master_cidr_offset) }
+  # range_base: cidrsubnet("172.16.0.0/12", 5, i) gives 172.16.0.0/17, 172.17.0.0/17, 172.18.0.0/17 ...
+  master_cidr_offsets = { for env in local.sorted_envs : env => tostring(local.env_index[env]) }
   # Shared network name - gitops creates, others reference via data source
   shared_network_name = terraform.workspace == "gitops" ? module.shared-network[0].network_name : data.google_compute_network.shared_network[0].name
 

--- a/shared-network.tf
+++ b/shared-network.tf
@@ -13,7 +13,7 @@ module "shared-network" {
   network_name = "shared-gke-network"
 
   subnets = [
-    for env, cfg in local.environments : {
+    for env, cfg in var.environments : {
       subnet_name           = "gke-subnet-${env}"
       subnet_ip             = cfg.node_cidr
       subnet_region         = var.region
@@ -22,15 +22,15 @@ module "shared-network" {
   ]
 
   secondary_ranges = {
-    for env, cfg in local.environments :
+    for env, cfg in var.environments :
     "gke-subnet-${env}" => [
       {
         range_name    = "${env}-pods"
-        ip_cidr_range = cidrsubnet(cfg.range_base, 1, 0)
+        ip_cidr_range = cidrsubnet(cidrsubnet("172.16.0.0/12", 5, local.env_index[env]), 1, 0)
       },
       {
         range_name    = "${env}-services"
-        ip_cidr_range = cidrsubnet(cfg.range_base, 1, 1)
+        ip_cidr_range = cidrsubnet(cidrsubnet("172.16.0.0/12", 5, local.env_index[env]), 1, 1)
       },
     ]
   }

--- a/shared-network.tf
+++ b/shared-network.tf
@@ -26,11 +26,11 @@ module "shared-network" {
     "gke-subnet-${env}" => [
       {
         range_name    = "${env}-pods"
-        ip_cidr_range = cidrsubnet(cidrsubnet("172.16.0.0/12", 5, local.env_index[env]), 1, 0)
+        ip_cidr_range = cidrsubnet(cfg.range_base, 1, 0)
       },
       {
         range_name    = "${env}-services"
-        ip_cidr_range = cidrsubnet(cidrsubnet("172.16.0.0/12", 5, local.env_index[env]), 1, 1)
+        ip_cidr_range = cidrsubnet(cfg.range_base, 1, 1)
       },
     ]
   }

--- a/shared-network.tf
+++ b/shared-network.tf
@@ -2,6 +2,32 @@
 # GitOps workspace creates and manages the shared network
 # Dev and Staging workspaces reference it via data source
 
+locals {
+  # One entry per environment: defines the node subnet base and the
+  # secondary-range base from which pods (/18) and services (/18) are derived.
+  #
+  # node_cidr  : the /17 assigned to cluster nodes
+  # range_base : a /17 from which cidrsubnet carves pods and services as /18s
+  #
+  # Resulting secondary ranges:
+  #   pods     = cidrsubnet(range_base, 1, 0)  → first  /18 of the /17
+  #   services = cidrsubnet(range_base, 1, 1)  → second /18 of the /17
+  env_network = {
+    dev = {
+      node_cidr  = "10.10.0.0/17"
+      range_base = "172.16.0.0/17"
+    }
+    staging = {
+      node_cidr  = "10.20.0.0/17"
+      range_base = "172.17.0.0/17"
+    }
+    gitops = {
+      node_cidr  = "10.30.0.0/17"
+      range_base = "172.18.0.0/17"
+    }
+  }
+}
+
 # Shared VPC Network (created only in gitops workspace)
 module "shared-network" {
   count = terraform.workspace == "gitops" ? 1 : 0
@@ -13,58 +39,24 @@ module "shared-network" {
   network_name = "shared-gke-network"
 
   subnets = [
-    # Dev environment subnet
-    {
-      subnet_name           = "gke-subnet-dev"
-      subnet_ip            = "10.10.0.0/17"
-      subnet_region        = var.region
-      subnet_private_access = "true"
-    },
-    # Staging environment subnet
-    {
-      subnet_name           = "gke-subnet-staging"
-      subnet_ip            = "10.20.0.0/17"
-      subnet_region        = var.region
-      subnet_private_access = "true"
-    },
-    # GitOps environment subnet
-    {
-      subnet_name           = "gke-subnet-gitops"
-      subnet_ip            = "10.30.0.0/17"
-      subnet_region        = var.region
+    for env, cfg in local.env_network : {
+      subnet_name           = "gke-subnet-${env}"
+      subnet_ip             = cfg.node_cidr
+      subnet_region         = var.region
       subnet_private_access = "true"
     }
   ]
 
   secondary_ranges = {
-    "gke-subnet-dev" = [
+    for env, cfg in local.env_network :
+    "gke-subnet-${env}" => [
       {
-        range_name    = "dev-pods"
-        ip_cidr_range = "172.16.0.0/18"
+        range_name    = "${env}-pods"
+        ip_cidr_range = cidrsubnet(cfg.range_base, 1, 0)
       },
       {
-        range_name    = "dev-services"
-        ip_cidr_range = "172.16.64.0/18"
-      },
-    ]
-    "gke-subnet-staging" = [
-      {
-        range_name    = "staging-pods"
-        ip_cidr_range = "172.17.0.0/18"
-      },
-      {
-        range_name    = "staging-services"
-        ip_cidr_range = "172.17.64.0/18"
-      },
-    ]
-    "gke-subnet-gitops" = [
-      {
-        range_name    = "gitops-pods"
-        ip_cidr_range = "172.18.0.0/18"
-      },
-      {
-        range_name    = "gitops-services"
-        ip_cidr_range = "172.18.64.0/18"
+        range_name    = "${env}-services"
+        ip_cidr_range = cidrsubnet(cfg.range_base, 1, 1)
       },
     ]
   }
@@ -100,14 +92,4 @@ resource "google_compute_router_nat" "shared_nat" {
     enable = true
     filter = "ERRORS_ONLY"
   }
-
-  # Optional: Reserve static NAT IPs for better IP allowlisting
-  # nat_ips = [google_compute_address.nat_ip.self_link]
 }
-
-# Optional: Static NAT IP for consistent outbound IP
-# resource "google_compute_address" "nat_ip" {
-#   project = var.project_id
-#   name    = "shared-nat-ip"
-#   region  = var.region
-# }

--- a/shared-network.tf
+++ b/shared-network.tf
@@ -2,32 +2,6 @@
 # GitOps workspace creates and manages the shared network
 # Dev and Staging workspaces reference it via data source
 
-locals {
-  # One entry per environment: defines the node subnet base and the
-  # secondary-range base from which pods (/18) and services (/18) are derived.
-  #
-  # node_cidr  : the /17 assigned to cluster nodes
-  # range_base : a /17 from which cidrsubnet carves pods and services as /18s
-  #
-  # Resulting secondary ranges:
-  #   pods     = cidrsubnet(range_base, 1, 0)  → first  /18 of the /17
-  #   services = cidrsubnet(range_base, 1, 1)  → second /18 of the /17
-  env_network = {
-    dev = {
-      node_cidr  = "10.10.0.0/17"
-      range_base = "172.16.0.0/17"
-    }
-    staging = {
-      node_cidr  = "10.20.0.0/17"
-      range_base = "172.17.0.0/17"
-    }
-    gitops = {
-      node_cidr  = "10.30.0.0/17"
-      range_base = "172.18.0.0/17"
-    }
-  }
-}
-
 # Shared VPC Network (created only in gitops workspace)
 module "shared-network" {
   count = terraform.workspace == "gitops" ? 1 : 0
@@ -39,7 +13,7 @@ module "shared-network" {
   network_name = "shared-gke-network"
 
   subnets = [
-    for env, cfg in local.env_network : {
+    for env, cfg in local.environments : {
       subnet_name           = "gke-subnet-${env}"
       subnet_ip             = cfg.node_cidr
       subnet_region         = var.region
@@ -48,7 +22,7 @@ module "shared-network" {
   ]
 
   secondary_ranges = {
-    for env, cfg in local.env_network :
+    for env, cfg in local.environments :
     "gke-subnet-${env}" => [
       {
         range_name    = "${env}-pods"

--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -10,6 +10,17 @@ zones               = ["us-central1-c", "us-central1-b", "us-central1-a"] # Zone
 cluster_name_suffix = "dev"                                               # Suffix to append to the cluster name indicating the environment
 
 
+# Environments
+# To add a new environment (e.g. "prod"):
+#   1. Add an entry below with a unique node_cidr, range_base, and master_cidr_offset
+#   2. Create gke-applications/prod/ with app definitions
+#   3. Run: terraform workspace new prod && terraform apply
+environments = {
+  dev     = { node_cidr = "10.10.0.0/17" }
+  gitops  = { node_cidr = "10.30.0.0/17" }
+  staging = { node_cidr = "10.20.0.0/17" }
+}
+
 # ArgoCD Configuration
 # Sets up ArgoCD in the cluster to manage deployments and configurations.
 argocd = {

--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -16,9 +16,21 @@ cluster_name_suffix = "dev"                                               # Suff
 #   2. Create gke-applications/prod/ with app definitions
 #   3. Run: terraform workspace new prod && terraform apply
 environments = {
-  dev     = { node_cidr = "10.10.0.0/17" }
-  gitops  = { node_cidr = "10.30.0.0/17" }
-  staging = { node_cidr = "10.20.0.0/17" }
+  dev = {
+    node_cidr          = "10.10.0.0/17"
+    range_base         = "172.16.0.0/17"
+    master_cidr_offset = 0
+  }
+  staging = {
+    node_cidr          = "10.20.0.0/17"
+    range_base         = "172.17.0.0/17"
+    master_cidr_offset = 1
+  }
+  gitops = {
+    node_cidr          = "10.30.0.0/17"
+    range_base         = "172.18.0.0/17"
+    master_cidr_offset = 2
+  }
 }
 
 # ArgoCD Configuration

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,13 @@ variable "cluster_autoscaling" {
 
 
 
+variable "environments" {
+  description = "Map of environments. Each entry provisions a GKE cluster, subnet, and secondary IP ranges. To add a new environment, add an entry here and run: terraform workspace new <name> && terraform apply"
+  type = map(object({
+    node_cidr = string
+  }))
+}
+
 variable "eso_version" {
   description = "External Secrets Operator version - used for CRD installation and chart deployment"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -56,9 +56,11 @@ variable "cluster_autoscaling" {
 
 
 variable "environments" {
-  description = "Map of environments. Each entry provisions a GKE cluster, subnet, and secondary IP ranges. To add a new environment, add an entry here and run: terraform workspace new <name> && terraform apply"
+  description = "Map of environments. Each entry provisions a GKE cluster, subnet, and secondary IP ranges. CIDRs must be unique and stable — changing them forces cluster recreation. To add a new environment, add an entry with non-overlapping CIDRs and the next available master_cidr_offset."
   type = map(object({
-    node_cidr = string
+    node_cidr          = string
+    range_base         = string
+    master_cidr_offset = number
   }))
 }
 


### PR DESCRIPTION
## Summary

- **Environments as variable**: Move environment definitions from `locals.tf` to `var.environments` in `values.auto.tfvars`. Adding a new environment now only requires one line in tfvars (`prod = { node_cidr = "..." }`), all subnets, secondary ranges, and master CIDRs are derived automatically
- **CIDR derivation**: Drop `range_base` and `master_cidr_offset` fields — both are now derived from the alphabetical sort index of environment names via `cidrsubnet`
- **Pipeline loop refactor**: Replace hardcoded per-workspace steps in all 4 pipeline files with a single looping step driven by `_WORKSPACES` / `_REMOTE_WORKSPACES` substitution variables — adding an environment now requires updating one variable per pipeline file
- **Alpine 3.21**: Update all alpine image references from `3.18`/`latest` to `3.21`

## Test plan

- [ ] `terraform validate` passes (already verified locally)
- [ ] Open a test PR and confirm plan pipeline runs all workspaces via the loop
- [ ] Confirm apply pipeline processes gitops → dev → staging in order on merge
- [ ] Verify no CIDR overlap in the derived secondary ranges