### PR TITLE
Change schedule: destroy all nightly, recreate Mondays only

### DIFF
--- a/cloudbuild-create.yaml
+++ b/cloudbuild-create.yaml
@@ -1,0 +1,238 @@
+steps:
+# Environment Info
+- name: alpine:3.18
+  id: environment-info
+  entrypoint: /bin/sh
+  args:
+  - -c
+  - |
+    echo "=== Weekly Recreation - All Workspaces ==="
+    echo "Build ID: $BUILD_ID"
+    echo "Triggered at: $(date)"
+    echo "Workspaces to create: gitops, dev, staging"
+    echo "Order: gitops (network first) -> dev -> staging"
+    echo "============================================"
+  timeout: 60s
+
+# Terraform Init (shared)
+- id: terraform-init
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  args:
+  - -c
+  - |
+    set -e
+    terraform init -backend-config="prefix=terraform/state"
+  timeout: 300s
+
+###################
+# GITOPS WORKSPACE - CREATE (first - creates shared network)
+###################
+
+- id: setup-gitops
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  waitFor:
+  - terraform-init
+  args:
+  - -c
+  - |
+    workspace_name="gitops"
+    echo "Selecting workspace: $workspace_name"
+    terraform workspace select $workspace_name || terraform workspace new $workspace_name
+    terraform workspace show
+  timeout: 300s
+
+- id: plan-gitops
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  waitFor:
+  - setup-gitops
+  args:
+  - -c
+  - |
+    set -euo pipefail
+    workspace_name="gitops"
+    plan_file="/workspace/$BUILD_ID/tfplan_gitops"
+
+    echo "Creating plan for workspace: $workspace_name"
+    mkdir -p "/workspace/$BUILD_ID"
+    terraform workspace select $workspace_name
+    terraform plan -out="$plan_file"
+    echo "Plan created: $plan_file"
+  timeout: 600s
+
+- id: apply-gitops
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  waitFor:
+  - plan-gitops
+  args:
+  - -c
+  - |
+    set -euo pipefail
+    workspace_name="gitops"
+    plan_file="/workspace/$BUILD_ID/tfplan_gitops"
+
+    echo "================================"
+    echo "Applying workspace: $workspace_name"
+    echo "NOTE: Creates shared network first"
+    echo "================================"
+
+    terraform workspace select $workspace_name
+
+    if terraform apply "$plan_file"; then
+        echo "Successfully applied workspace: $workspace_name"
+    else
+        echo "ERROR: Apply failed for workspace: $workspace_name"
+        exit 1
+    fi
+  timeout: 1800s
+
+###################
+# DEV WORKSPACE - CREATE (second)
+###################
+
+- id: setup-dev
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  waitFor:
+  - apply-gitops
+  args:
+  - -c
+  - |
+    workspace_name="dev"
+    echo "Selecting workspace: $workspace_name"
+    terraform workspace select $workspace_name || terraform workspace new $workspace_name
+    terraform workspace show
+  timeout: 300s
+
+- id: plan-dev
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  waitFor:
+  - setup-dev
+  args:
+  - -c
+  - |
+    set -euo pipefail
+    workspace_name="dev"
+    plan_file="/workspace/$BUILD_ID/tfplan_dev"
+
+    echo "Creating plan for workspace: $workspace_name"
+    mkdir -p "/workspace/$BUILD_ID"
+    terraform workspace select $workspace_name
+    terraform plan -out="$plan_file"
+    echo "Plan created: $plan_file"
+  timeout: 600s
+
+- id: apply-dev
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  waitFor:
+  - plan-dev
+  args:
+  - -c
+  - |
+    set -euo pipefail
+    workspace_name="dev"
+    plan_file="/workspace/$BUILD_ID/tfplan_dev"
+
+    echo "================================"
+    echo "Applying workspace: $workspace_name"
+    echo "================================"
+
+    terraform workspace select $workspace_name
+
+    if terraform apply "$plan_file"; then
+        echo "Successfully applied workspace: $workspace_name"
+    else
+        echo "ERROR: Apply failed for workspace: $workspace_name"
+        exit 1
+    fi
+  timeout: 1800s
+
+###################
+# STAGING WORKSPACE - CREATE (third)
+###################
+
+- id: setup-staging
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  waitFor:
+  - apply-dev
+  args:
+  - -c
+  - |
+    workspace_name="staging"
+    echo "Selecting workspace: $workspace_name"
+    terraform workspace select $workspace_name || terraform workspace new $workspace_name
+    terraform workspace show
+  timeout: 300s
+
+- id: plan-staging
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  waitFor:
+  - setup-staging
+  args:
+  - -c
+  - |
+    set -euo pipefail
+    workspace_name="staging"
+    plan_file="/workspace/$BUILD_ID/tfplan_staging"
+
+    echo "Creating plan for workspace: $workspace_name"
+    mkdir -p "/workspace/$BUILD_ID"
+    terraform workspace select $workspace_name
+    terraform plan -out="$plan_file"
+    echo "Plan created: $plan_file"
+  timeout: 600s
+
+- id: apply-staging
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  waitFor:
+  - plan-staging
+  args:
+  - -c
+  - |
+    set -euo pipefail
+    workspace_name="staging"
+    plan_file="/workspace/$BUILD_ID/tfplan_staging"
+
+    echo "================================"
+    echo "Applying workspace: $workspace_name"
+    echo "================================"
+
+    terraform workspace select $workspace_name
+
+    if terraform apply "$plan_file"; then
+        echo "Successfully applied workspace: $workspace_name"
+    else
+        echo "ERROR: Apply failed for workspace: $workspace_name"
+        exit 1
+    fi
+  timeout: 1800s
+
+# Summary
+- name: alpine:3.18
+  id: create-summary
+  entrypoint: /bin/sh
+  args:
+  - -c
+  - |
+    echo "================================"
+    echo "Weekly Recreation Complete"
+    echo "Recreated: gitops, dev, staging"
+    echo "Shared network: CREATED (by gitops)"
+    echo "Completed at: $(date)"
+    echo "Next destroy: Tonight 2 AM EST"
+    echo "================================"
+  timeout: 60s
+
+options:
+  machineType: E2_HIGHCPU_8
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: 7200s

--- a/cloudbuild-destroy.yaml
+++ b/cloudbuild-destroy.yaml
@@ -1,0 +1,163 @@
+steps:
+# Environment Info
+- name: alpine:3.18
+  id: environment-info
+  entrypoint: /bin/sh
+  args:
+  - -c
+  - |
+    echo "=== Scheduled Destroy - All Workspaces ==="
+    echo "Build ID: $BUILD_ID"
+    echo "Triggered at: $(date)"
+    echo "Workspaces to destroy: dev, staging, gitops"
+    echo "Order: dev -> staging -> gitops (network last)"
+    echo "============================================"
+  timeout: 60s
+
+# Terraform Init (shared)
+- id: terraform-init
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  args:
+  - -c
+  - |
+    set -e
+    terraform init -backend-config="prefix=terraform/state"
+  timeout: 300s
+
+###################
+# DEV WORKSPACE - DESTROY (first)
+###################
+
+- id: destroy-dev
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  waitFor:
+  - terraform-init
+  args:
+  - -c
+  - |
+    set -euo pipefail
+
+    workspace_name="dev"
+    echo "================================"
+    echo "DESTROYING workspace: $workspace_name"
+    echo "Creating state backup before destroy..."
+    echo "================================"
+
+    terraform workspace select $workspace_name || terraform workspace new $workspace_name
+
+    if terraform state pull > /tmp/terraform_${workspace_name}_predestroy_${BUILD_ID}.tfstate 2>/dev/null; then
+        echo "State backup created"
+
+        echo "Starting destroy operation..."
+        if terraform destroy -auto-approve; then
+            echo "Successfully destroyed workspace: $workspace_name"
+        else
+            echo "ERROR: Failed to destroy workspace: $workspace_name"
+            echo "Backup available at: /tmp/terraform_${workspace_name}_predestroy_${BUILD_ID}.tfstate"
+            exit 1
+        fi
+    else
+        echo "No state found for workspace: $workspace_name - skipping"
+    fi
+  timeout: 1800s
+
+###################
+# STAGING WORKSPACE - DESTROY (second)
+###################
+
+- id: destroy-staging
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  waitFor:
+  - destroy-dev
+  args:
+  - -c
+  - |
+    set -euo pipefail
+
+    workspace_name="staging"
+    echo "================================"
+    echo "DESTROYING workspace: $workspace_name"
+    echo "Creating state backup before destroy..."
+    echo "================================"
+
+    terraform workspace select $workspace_name || terraform workspace new $workspace_name
+
+    if terraform state pull > /tmp/terraform_${workspace_name}_predestroy_${BUILD_ID}.tfstate 2>/dev/null; then
+        echo "State backup created"
+
+        echo "Starting destroy operation..."
+        if terraform destroy -auto-approve; then
+            echo "Successfully destroyed workspace: $workspace_name"
+        else
+            echo "ERROR: Failed to destroy workspace: $workspace_name"
+            echo "Backup available at: /tmp/terraform_${workspace_name}_predestroy_${BUILD_ID}.tfstate"
+            exit 1
+        fi
+    else
+        echo "No state found for workspace: $workspace_name - skipping"
+    fi
+  timeout: 1800s
+
+###################
+# GITOPS WORKSPACE - DESTROY (last - manages shared network)
+###################
+
+- id: destroy-gitops
+  name: hashicorp/terraform:1.11
+  entrypoint: /bin/sh
+  waitFor:
+  - destroy-staging
+  args:
+  - -c
+  - |
+    set -euo pipefail
+
+    workspace_name="gitops"
+    echo "================================"
+    echo "DESTROYING workspace: $workspace_name"
+    echo "NOTE: This workspace manages the shared network"
+    echo "Creating state backup before destroy..."
+    echo "================================"
+
+    terraform workspace select $workspace_name || terraform workspace new $workspace_name
+
+    if terraform state pull > /tmp/terraform_${workspace_name}_predestroy_${BUILD_ID}.tfstate 2>/dev/null; then
+        echo "State backup created"
+
+        echo "Starting destroy operation..."
+        if terraform destroy -auto-approve; then
+            echo "Successfully destroyed workspace: $workspace_name"
+        else
+            echo "ERROR: Failed to destroy workspace: $workspace_name"
+            echo "Backup available at: /tmp/terraform_${workspace_name}_predestroy_${BUILD_ID}.tfstate"
+            exit 1
+        fi
+    else
+        echo "No state found for workspace: $workspace_name - skipping"
+    fi
+  timeout: 1800s
+
+# Summary
+- name: alpine:3.18
+  id: destroy-summary
+  entrypoint: /bin/sh
+  args:
+  - -c
+  - |
+    echo "================================"
+    echo "Scheduled Destroy Complete"
+    echo "Destroyed: dev, staging, gitops"
+    echo "Shared network: DESTROYED"
+    echo "Completed at: $(date)"
+    echo "Next recreation: Monday 10 AM EST"
+    echo "================================"
+  timeout: 60s
+
+options:
+  machineType: E2_HIGHCPU_8
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: 7200s

--- a/docs/SCHEDULED-DESTROY.md
+++ b/docs/SCHEDULED-DESTROY.md
@@ -1,22 +1,23 @@
 # Scheduled Destroy & Recreate
 
-Automatically destroy and recreate dev/staging workspaces to save costs during off-hours.
+Automatically destroy all workspaces nightly and recreate weekly to save costs.
 
 ## 📅 Schedule
 
 | Action | Time | Workspaces | Frequency |
 |--------|------|------------|-----------|
-| **Destroy** | 2 AM EST | dev, staging | Daily |
-| **Recreate** | 10 AM EST | dev, staging | Daily |
+| **Destroy** | 2 AM EST | dev, staging, gitops | Every night |
+| **Recreate** | 10 AM EST | gitops, dev, staging | Monday only |
 
-**GitOps workspace**: Always running (manages shared network)
+**Destroy order**: dev → staging → gitops (network destroyed last)
+**Recreate order**: gitops → dev → staging (network created first)
 
 ## 💰 Cost Savings
 
-- **Dev cluster**: ~16 hours/day offline = 480 hours/month saved
-- **Staging cluster**: ~16 hours/day offline = 480 hours/month saved
-- **Total**: ~960 cluster-hours/month saved
-- **Estimated savings**: $200-400/month (depending on cluster size)
+- **All 3 clusters offline**: Mon night through next Mon morning
+- **Only online**: Monday 10 AM → Tuesday 2 AM (~16 hours/week)
+- **Offline**: ~152 hours/week
+- **Estimated savings**: $500-800/month (depending on cluster size)
 
 ## 🔧 Setup Instructions
 

--- a/scripts/cleanup-tf-state.sh
+++ b/scripts/cleanup-tf-state.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bash
+#!/opt/homebrew/bin/bash
 
 set -e
 

--- a/setup-scheduler-pubsub.sh
+++ b/setup-scheduler-pubsub.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Setup Cloud Scheduler using Pub/Sub (most reliable method)
+
+set -e
+
+PROJECT_ID="cluster-dreams"
+LOCATION="us-central1"
+
+echo "=========================================="
+echo "Cloud Scheduler Setup (Pub/Sub Method)"
+echo "=========================================="
+echo ""
+
+# Enable APIs
+echo "[1/5] Enabling APIs..."
+gcloud services enable \
+  cloudbuild.googleapis.com \
+  cloudscheduler.googleapis.com \
+  pubsub.googleapis.com \
+  --project="$PROJECT_ID"
+
+echo "✓ APIs enabled"
+echo ""
+
+# Create Pub/Sub topics
+echo "[2/5] Creating Pub/Sub topics..."
+
+gcloud pubsub topics create scheduled-destroy-trigger \
+  --project="$PROJECT_ID" 2>/dev/null || echo "  Topic already exists"
+
+gcloud pubsub topics create scheduled-create-trigger \
+  --project="$PROJECT_ID" 2>/dev/null || echo "  Topic already exists"
+
+echo "✓ Topics created"
+echo ""
+
+# Grant Pub/Sub permissions
+echo "[3/5] Configuring permissions..."
+
+PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format="value(projectNumber)")
+
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-pubsub.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountTokenCreator" \
+  --condition=None 2>/dev/null || echo "  Permission already granted"
+
+echo "✓ Permissions configured"
+echo ""
+
+# Create Cloud Scheduler jobs
+echo "[4/5] Creating scheduler jobs..."
+
+# Delete existing jobs
+gcloud scheduler jobs delete trigger-destroy-dev-staging \
+  --location="$LOCATION" \
+  --project="$PROJECT_ID" \
+  --quiet 2>/dev/null || true
+
+gcloud scheduler jobs delete trigger-create-dev-staging \
+  --location="$LOCATION" \
+  --project="$PROJECT_ID" \
+  --quiet 2>/dev/null || true
+
+# Create destroy job (2 AM EST every night)
+gcloud scheduler jobs create pubsub trigger-destroy-all-workspaces \
+  --project="$PROJECT_ID" \
+  --location="$LOCATION" \
+  --schedule="0 2 * * *" \
+  --time-zone="America/New_York" \
+  --topic="scheduled-destroy-trigger" \
+  --message-body='{"branchName":"main"}' \
+  --description="Destroy all workspaces (dev, staging, gitops) at 2 AM EST nightly"
+
+echo "✓ Destroy job created (2 AM EST nightly)"
+
+# Create recreate job (10 AM EST Monday only)
+gcloud scheduler jobs create pubsub trigger-create-all-workspaces \
+  --project="$PROJECT_ID" \
+  --location="$LOCATION" \
+  --schedule="0 10 * * 1" \
+  --time-zone="America/New_York" \
+  --topic="scheduled-create-trigger" \
+  --message-body='{"branchName":"main"}' \
+  --description="Recreate all workspaces (gitops, dev, staging) at 10 AM EST every Monday"
+
+echo "✓ Recreate job created (10 AM EST Mondays only)"
+echo ""
+
+# Summary
+echo "[5/5] Verifying setup..."
+echo ""
+gcloud scheduler jobs list --location="$LOCATION" --project="$PROJECT_ID"
+
+echo ""
+echo "=========================================="
+echo "Setup Complete!"
+echo "=========================================="
+echo ""
+echo "⚠️  IMPORTANT: Connect Cloud Build Triggers"
+echo ""
+echo "You must now connect these Pub/Sub topics to Cloud Build triggers:"
+echo ""
+echo "1. Go to: https://console.cloud.google.com/cloud-build/triggers?project=$PROJECT_ID"
+echo ""
+echo "2. Create or edit trigger 'scheduled-destroy-dev-staging':"
+echo "   - Event: Pub/Sub message"
+echo "   - Topic: scheduled-destroy-trigger"
+echo "   - Branch: ^main$"
+echo "   - Configuration: cloudbuild-destroy.yaml"
+echo ""
+echo "3. Create or edit trigger 'scheduled-create-dev-staging':"
+echo "   - Event: Pub/Sub message"
+echo "   - Topic: scheduled-create-trigger"
+echo "   - Branch: ^main$"
+echo "   - Configuration: cloudbuild-create.yaml"
+echo ""
+echo "=========================================="
+echo "Testing"
+echo "=========================================="
+echo ""
+echo "Test the scheduler manually:"
+echo ""
+echo "  gcloud scheduler jobs run trigger-destroy-dev-staging --location=$LOCATION"
+echo "  gcloud scheduler jobs run trigger-create-dev-staging --location=$LOCATION"
+echo ""
+echo "Monitor builds:"
+echo ""
+echo "  gcloud builds list --limit=5"
+echo ""
+echo "Pause/resume:"
+echo ""
+echo "  gcloud scheduler jobs pause trigger-destroy-dev-staging --location=$LOCATION"
+echo "  gcloud scheduler jobs resume trigger-destroy-dev-staging --location=$LOCATION"
+echo ""


### PR DESCRIPTION
Updated schedule:
- Destroy: 2 AM EST every night (dev, staging, gitops)
- Recreate: 10 AM EST Monday only (gitops, dev, staging)

Key changes:
- Added gitops to destroy/recreate pipelines
- Destroy order: dev -> staging -> gitops (network last)
- Recreate order: gitops -> dev -> staging (network first)
- Recreate cron changed from daily (0 10 * * *) to Monday (0 10 * * 1)
- Increased timeout to 7200s for 3-workspace operations

https://claude.ai/code/session_011CUyCZTyJkidQosuhSRALT